### PR TITLE
[sapp] fix logo

### DIFF
--- a/sapp/ui/frontend/src/Issue.js
+++ b/sapp/ui/frontend/src/Issue.js
@@ -163,7 +163,6 @@ export function Issue(
   return (
     <Card
       size="small"
-      style={{margin: '0 10px 0 10px'}}
       title={
         <>
           <FireOutlined style={{marginRight: '.5em'}} />

--- a/sapp/ui/frontend/src/Issues.css
+++ b/sapp/ui/frontend/src/Issues.css
@@ -6,7 +6,7 @@
  */
 
 .main {
-  max-width: 1200px;
+  max-width: 1000px;
   margin: 0 auto;
 }
 

--- a/sapp/ui/frontend/src/index.css
+++ b/sapp/ui/frontend/src/index.css
@@ -22,6 +22,6 @@ code {
 .logo {
   color: white;
   font-size: 20px;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto 0 auto;
 }


### PR DESCRIPTION
we changed the size of the issue box but that meant the logo would no longer align. Realigning the logo with this commit.

Test plan:

<img width="1257" alt="Screen Shot 2021-04-27 at 5 32 22 PM" src="https://user-images.githubusercontent.com/270421/116328916-ebe05e80-a77e-11eb-8bda-af0e5e3a5a24.png">
