### PR TITLE
[sapp] less threatening visualization of file-not-found in traces

### DIFF
--- a/sapp/ui/frontend/src/Source.js
+++ b/sapp/ui/frontend/src/Source.js
@@ -159,10 +159,12 @@ function Source(
   var content = <div />;
   if (error) {
     content = (
-      <Alert
-        message={`Unable to load ${props.path} (${error.toString()})`}
-        type="error"
-      />
+      <Tooltip title={error.toString()}>
+        <Alert
+          message={`No file found for ${props.path}`}
+          type="info"
+        />
+      </Tooltip>
     );
   } else if (loading) {
     content = (


### PR DESCRIPTION
It's common for endpoints of traces to not have source code that we can display. Previously this would always be displayed as an error. Making this an informational dialog instead.