### PR TITLE
Added updating to saved filters

### DIFF
--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -87,7 +87,9 @@ def save_filter(session: Session, filter: Filter) -> None:
         session.add(FilterRecord.from_filter(filter))
         LOG.debug(f"Adding {filter}")
     else:
+        # pyre-ignore [8]: `graphene.String` is not compatible with `str`
         existing.description = filter.description
+        # pyre-ignore [8]: `graphene.String` is not compatible with `str`
         existing.json = filter.json
         LOG.debug(f"Updating {filter}")
 

--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -79,8 +79,10 @@ def all_filters(session: Session) -> List[Filter]:
 
 def save_filter(session: Session, filter: Filter) -> None:
 
-    existing = session.query(FilterRecord).filter(FilterRecord.name == filter.name).first()
-    
+    existing = (
+        session.query(FilterRecord).filter(FilterRecord.name == filter.name).first()
+    )
+
     if not existing:
         session.add(FilterRecord.from_filter(filter))
         LOG.debug(f"Adding {filter}")

--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -78,8 +78,17 @@ def all_filters(session: Session) -> List[Filter]:
 
 
 def save_filter(session: Session, filter: Filter) -> None:
-    LOG.debug(f"Storing {filter}")
-    session.add(FilterRecord.from_filter(filter))
+
+    existing = session.query(FilterRecord).filter(FilterRecord.name == filter.name).first()
+    
+    if not existing:
+        session.add(FilterRecord.from_filter(filter))
+        LOG.debug(f"Adding {filter}")
+    else:
+        existing.description = filter.description
+        existing.json = filter.json
+        LOG.debug(f"Updating {filter}")
+
     session.commit()
 
 


### PR DESCRIPTION
This PR refers to #21 and adds the ability to update the filter field of a saved field from the web UI. 

To do this, there’s just a couple of new changes in `filters.py` which inserts the new filter into the database or updates it (if the filter name already exists).

I first dug around a bit in the docs to see if there was anything like `UPSERT` available for SQLAlchemy, but I think many people online recommended to just query the database and update the fields manually (which seems to be alright, since there are only two fields that need to be updated in the object). I manually tested updating the filter fields manually to check that it works for all the filter options (codes, paths, callables, features, status, and trace lengths).

Please let me know if I missed something or if there’s anything that should be fixed/improved!