### PR TITLE
Adds ability to copy source code in a Trace

### DIFF
--- a/sapp/ui/frontend/src/Source.css
+++ b/sapp/ui/frontend/src/Source.css
@@ -51,3 +51,7 @@
 ::-webkit-resizer {
   border-bottom: 2px solid lightgray;
 }
+
+.CodeMirror-cursor {
+  display: none !important;
+}

--- a/sapp/ui/frontend/src/Source.js
+++ b/sapp/ui/frontend/src/Source.js
@@ -197,7 +197,7 @@ function Source(
     content = (
       <CodeMirror
         value={source}
-        options={{lineNumbers: true, readOnly: 'nocursor'}}
+        options={{lineNumbers: true, readOnly: 'true'}}
         editorDidMount={nativeEditor => {
           editor = nativeEditor;
 


### PR DESCRIPTION
Add ability to copy source code in a trace. Previously copy, cut, and
paste operations were disabled. Now enabled copy. Even though paste and
cut appears in browser ui, nothing happens when they are clicked.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes https://github.com/MLH-Fellowship/pyre-check/issues/28