### PR TITLE
Allow users to delete previously imported runs

### DIFF
--- a/sapp/ui/schema.py
+++ b/sapp/ui/schema.py
@@ -260,11 +260,24 @@ class DeleteFilterMutation(relay.ClientIDMutation):
         return DeleteFilterMutation()
 
 
+class DeleteRunMutation(relay.ClientIDMutation):
+    class Input:
+        id = graphene.ID(required=True)
+
+    def mutate_and_get_payload(
+        self, info: ResolveInfo, **kwargs: Any
+    ) -> "DeleteRunMutation":
+        session = info.context.get("session")
+        run.delete_run(session, kwargs["id"])
+        return DeleteRunMutation()
+
+
 class Mutation(graphene.ObjectType):
     # pyre-fixme[4]: Attribute must be annotated.
     save_filter = SaveFilterMutation.Field()
     # pyre-fixme[4]: Attribute must be annotated.
     delete_filter = DeleteFilterMutation.Field()
+    delete_run: DeleteRunMutation = DeleteRunMutation.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation, auto_camelcase=False)


### PR DESCRIPTION
Allow users to delete previously imported runs through the Web UI.
Modifies Run.js to include new delete icon. Adds new mutation to
schema.py which calls delete run function through run.py.

The delete run function deletes instances of a run with the given id,
issue instances that bind an issue with a run, and also tuples from
others tables that reference run_id.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/27