### PR TITLE
Create easier access to selecting saved filters

### DIFF
--- a/sapp/ui/frontend/src/Filter.css
+++ b/sapp/ui/frontend/src/Filter.css
@@ -33,3 +33,11 @@
 .ant-collapse-content-box{
     padding: 1px !important;
 }
+
+.ant-layout-sider{
+    background: none !important;
+}
+
+.ant-menu-submenu-title{
+    padding-left: 16px !important;
+}

--- a/sapp/ui/frontend/src/Issues.js
+++ b/sapp/ui/frontend/src/Issues.js
@@ -10,8 +10,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { useQuery, gql } from '@apollo/client';
-import { Button, Modal, Breadcrumb } from 'antd';
-import Filter, { loadFilter, filterToVariables } from './Filter';
+import { Button, Layout, Modal, Breadcrumb } from 'antd';
+import FilterControls, { loadFilter, filterToVariables } from './Filter';
 import { Issue, IssueSkeleton } from './Issue.js';
 
 import { MoreOutlined } from '@ant-design/icons';
@@ -171,12 +171,18 @@ const Issues = (props: $ReadOnly<{ match: any }>): React$Node => {
 
   return (
     <>
-      <Filter refetch={clearAndRefetch} refetching={refetching} />
       <Breadcrumb style={{ margin: '16px 0' }}>
         <Breadcrumb.Item href="/runs">Runs</Breadcrumb.Item>
         <Breadcrumb.Item>Run {run_id}</Breadcrumb.Item>
       </Breadcrumb>
-      {content}
+      <Layout>
+        <Layout style={{ paddingRight: '24px' }}>
+          {content}
+        </Layout>
+        <FilterControls
+          refetch={clearAndRefetch}
+          refetching={refetching} />
+      </Layout>
     </>
   );
 };


### PR DESCRIPTION
Creates easier access to selecting web filters by moving saved filters
out of the filter form to a seperate popup. Now clicking the saved
filter applies the filter (and perfomes the page reload).

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/30