### PR TITLE
Don't persist issue filters accross Runs

### DIFF
--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -827,6 +827,23 @@ export function loadFilter(): ?FilterDescription {
   return null;
 }
 
+export function clearFilter(
+  refetch: any = false,
+  setCurrentFilter: any = false,
+  currentFilter: FilterDescription = emptyFilter,
+): void {
+  if(!refetch) {
+    window.sessionStorage.removeItem('filter');
+  } else  {
+    setCurrentFilter(emptyFilter);
+    // workaround for https://github.com/apollographql/react-apollo/issues/3709
+    // implemented in clearAndRefetch function makes us implement this hacky
+    // solution. Otherwise, the app just keeps loading and does nothing.
+    refetch(filterToVariables(emptyFilter));
+    refetch(filterToVariables(currentFilter));
+  }
+}
+
 export function filterToVariables(filter: FilterDescription): mixed {
   const rangeValue = value => {
     if (value === 0) {

--- a/sapp/ui/frontend/src/Runs.js
+++ b/sapp/ui/frontend/src/Runs.js
@@ -12,6 +12,7 @@ import React, {useState} from 'react';
 import {useQuery, useMutation, gql} from '@apollo/client';
 import {Breadcrumb, Card, Col, Modal, Row, Typography} from 'antd';
 import {DeleteOutlined, LoadingOutlined, SyncOutlined} from '@ant-design/icons';
+import {clearFilter} from './Filter';
 
 const {Text, Link} = Typography;
 
@@ -74,7 +75,13 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
             Run {props.run.run_id}
           </>
         }
-        extra={<Link href={`/run/${props.run.run_id}`}>Issues</Link>}
+        extra={
+          <Link
+            onClick={() => clearFilter()}
+            href={`/run/${props.run.run_id}`}>
+            Issues
+          </Link>
+        }
         actions={[
           <DeleteOutlined onClick={onDelete}/>
         ]}>


### PR DESCRIPTION
Adds clear filter button beside the Filter button to clear spplied
filters instantly thereby reducing the number of interactions required
to stop filtering to one.

The button will only be visible if filters are applied.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/33