### PR TITLE
Adds ability to export existing filters

### DIFF
--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -31,6 +31,7 @@ import {
   Typography,
 } from 'antd';
 import {
+  ExportOutlined,
   FieldTimeOutlined,
   FilterOutlined,
   PlusOutlined,
@@ -1070,6 +1071,19 @@ export const FilterControls = (props: {
             onClick={() => setDeleteModalVisible(true)}
             icon={<DeleteOutlined />}>
             Delete
+          </Menu.Item>
+          <Menu.Item
+            disabled={currentFilter?.name === undefined}
+            icon={<ExportOutlined />}>
+            {(currentFilter?.name === undefined) ? "Export" :
+              <a
+                href={`/export_filter/${currentFilter.name}`}
+                download={`${currentFilter.name}.json`}
+                target='_blank'
+                rel='noopener noreferrer'>
+                Export
+              </a>
+            }
           </Menu.Item>
         </SubMenu>
         <SubMenu

--- a/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
@@ -715,6 +715,11 @@ Array [
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
+                    style={
+                      Object {
+                        "minWidth": "130px",
+                      }
+                    }
                   >
                     <div
                       className="ant-select-selector"

--- a/sapp/ui/server.py
+++ b/sapp/ui/server.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from .. import models
 from ..db import DB
+from .filters import ServeExportFilter
 from .schema import schema
 
 logging.basicConfig(
@@ -90,6 +91,10 @@ def start_server(
                 "editor_schema": editor_schema,
             },
         ),
+    )
+    application.add_url_rule(
+        "/export_filter/<string:filter_name>",
+        view_func=ServeExportFilter.as_view("filter_export_view", session=session),
     )
     if static_resources:
         application.static_folder = static_resources


### PR DESCRIPTION
Adds ability to export an existing filter from the UI. Adds export
button to the filter options that when clicked downloads the filter json
file thereby exporting it.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/39