### PR TITLE
Mirror the Facebook internally used linter/formatter behaviour in the open source repository.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+select = B,C,E,F,P,T4,W,B9
+max-line-length = 80
+# E127, E128 are hard to silence in certain nested formatting situations.
+# E265, E266 talk about comment formatting which is too opinionated.
+# E402 warns on imports coming after statements. There are important use cases
+# like demandimport (https://fburl.com/demandimport) that require statements
+# before imports.
+# E501 is not flexible enough, we're using B950 instead.
+# E722 is a duplicate of B001.
+# P207 is a duplicate of B003.
+# W503 talks about operator formatting which is too opinionated.
+# E203 conflicts with Black
+ignore = E127, E128, E265, E266, E402, E501, E722, P207, W503, E203, T484
+max-complexity = 50
+exclude =
+  .git,
+  .hg,
+  __pycache__,
+  _build/*,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,48 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
 
-      - name: Install Dependencies
+      - name: Install black
+        run: pip install black==21.4b2
+
+      - name: Run black
+        run: black --check --diff .
+
+  usort:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install usort
+        run: pip install usort==0.6.4
+
+      - name: Run usort
+        run: usort diff . && usort check .
+
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        run: flake8
+
+  ESLint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install packages and run ESLint
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install black==20.8b1
-      - name: Run Black
-        run: |
-          black --check --diff .
+          cd sapp/ui/frontend
+          npm install
+          npm run lint

--- a/.pyproject.toml
+++ b/.pyproject.toml
@@ -1,0 +1,2 @@
+[tool.usort]
+first_party_detection = false

--- a/sapp/configuration.py
+++ b/sapp/configuration.py
@@ -1,9 +1,0 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-from typing import Optional
-
-GRAPHQL_PACKAGE: Optional[str] = None
-STRUCTURED_LOGGER_PACKAGE: Optional[str] = None

--- a/sapp/pipeline/mariana_trench_parser.py
+++ b/sapp/pipeline/mariana_trench_parser.py
@@ -24,12 +24,6 @@ from .. import pipeline as sapp
 from ..analysis_output import AnalysisOutput, Metadata
 from .base_parser import BaseParser
 
-try:
-    # type: ignore
-    from ...facebook.lib import configuration
-except Exception:
-    from .. import configuration
-
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:

--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -32,7 +32,7 @@ from ..models import (
 from .issues import Instance
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from pathlib import Path  # usort: skip. Wants trailing whitespace
 
     from .issues import IssueQueryResult  # noqa
 

--- a/sapp/ui/frontend/.eslintignore
+++ b/sapp/ui/frontend/.eslintignore
@@ -1,0 +1,5 @@
+# Third party
+**/node_modules
+
+# Build products
+**/build/

--- a/sapp/ui/frontend/config/webpack.config.js
+++ b/sapp/ui/frontend/config/webpack.config.js
@@ -42,8 +42,6 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 // makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
-const isExtendingEslintConfig = process.env.EXTEND_ESLINT === 'true';
-
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'
 );

--- a/sapp/ui/frontend/package.json
+++ b/sapp/ui/frontend/package.json
@@ -76,10 +76,16 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
-    "flow": "flow"
+    "flow": "flow",
+    "lint": "npx eslint . --max-warnings=0"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "eqeqeq": "off",
+      "strict": "off",
+      "default-case": "off"
+    }
   },
   "browserslist": {
     "production": [

--- a/sapp/ui/frontend/src/Issues.js
+++ b/sapp/ui/frontend/src/Issues.js
@@ -14,8 +14,6 @@ import { Button, Layout, Modal, Breadcrumb } from 'antd';
 import FilterControls, { loadFilter, filterToVariables } from './Filter';
 import { Issue, IssueSkeleton } from './Issue.js';
 
-import { MoreOutlined } from '@ant-design/icons';
-
 function IssuesList(props: $ReadOnly<{|
   issues: any,
   run_id: number,

--- a/sapp/ui/frontend/src/Traces.js
+++ b/sapp/ui/frontend/src/Traces.js
@@ -33,7 +33,6 @@ import {
 } from '@ant-design/icons';
 import {useQuery, gql} from '@apollo/client';
 import Source from './Source.js';
-import {Documentation} from './Documentation.js';
 import {Issue, IssueSkeleton} from './Issue.js';
 import {HumanReadable, HumanReadablePort} from './HumanReadable';
 

--- a/sapp/ui/issues.py
+++ b/sapp/ui/issues.py
@@ -47,6 +47,7 @@ SinkNameText = aliased(SharedText)
 # pyre-fixme[5]: Global expression must be annotated.
 SinkKindText = aliased(SharedText)
 
+
 # pyre-ignore[13]: unitialized class attribute
 class IssueQueryResultType(graphene.ObjectType):
     concatenated_features: str

--- a/sapp/ui/schema.py
+++ b/sapp/ui/schema.py
@@ -5,7 +5,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, List, NamedTuple, Optional
+from typing import Any, List, Optional
 
 import graphene
 from graphene import relay
@@ -13,7 +13,7 @@ from graphene_sqlalchemy import get_session
 from graphql.execution.base import ResolveInfo
 
 from ..filter import Filter
-from ..models import DBID, IssueStatus, TraceFrame, TraceKind
+from ..models import DBID, TraceFrame, TraceKind
 from . import filters as filters_module, issues, run, trace, typeahead
 from .issues import Instance, IssueQueryResult, IssueQueryResultType, update_status
 from .trace import TraceFrameQueryResult, TraceFrameQueryResultType

--- a/sapp/ui/tests/interactive_test.py
+++ b/sapp/ui/tests/interactive_test.py
@@ -20,8 +20,6 @@ from ...db import DB, DBType
 from ...decorators import UserError
 from ...models import (
     DBID,
-    Issue,
-    IssueInstance,
     IssueInstanceSharedTextAssoc,
     IssueInstanceTraceFrameAssoc,
     IssueStatus,

--- a/sapp/ui/tests/trace_test.py
+++ b/sapp/ui/tests/trace_test.py
@@ -7,13 +7,9 @@ import unittest
 from typing import Any, List
 from unittest import TestCase
 
-from sqlalchemy.sql import func
-
 from ...db import DB, DBType
 from ...models import (
     DBID,
-    Run,
-    RunStatus,
     SharedText,
     SharedTextKind,
     TraceFrameLeafAssoc,

--- a/sapp/ui/typeahead.py
+++ b/sapp/ui/typeahead.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import List, NamedTuple
+from typing import List
 
 import graphene
 from sqlalchemy.orm import Session

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 from pathlib import Path
 
 from setuptools import find_packages, setup

--- a/stubs/sqlalchemy/sql/schema.pyi
+++ b/stubs/sqlalchemy/sql/schema.pyi
@@ -117,6 +117,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):  # type: ignore
     ) -> Table: ...
 
 _C = TypeVar("_C", bound=Column)
+
 @final
 class Column(SchemaItem, ColumnClause[_T]):
     __visit_name__: str = ...


### PR DESCRIPTION
Mirror the Facebook internally used linter/formatter behaviour in the
open source repository.

Pins to black and usort versions used in the internal linter and runs
black, flake8, and usort in seperate runner instances.

Adds pyproject.toml with identical usort configuration as used
internally.

Modifies flake8 configuration to match the one used internally.

Fix errors reported by flake8, black, and usort.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/40