### PR TITLE
Allow user to update a saved filter without clear

### DIFF
--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -754,6 +754,12 @@ const SaveFilterModal = (
 ): React$Node => {
   const [form] = Form.useForm();
 
+  if(props.currentFilter.name !== undefined) {
+    form.setFieldsValue({
+      name: props.currentFilter.name,
+    });
+  }
+
   const onCompleted = (data: any): void => {
     const filter = {
       ...data.save_filter.node,
@@ -941,10 +947,7 @@ const SavedFilters = (
           overlay={
             <Menu>
               <Menu.Item
-                disabled={
-                  Object.keys(props.currentFilter).length === 0 ||
-                  props.currentFilter?.name !== undefined
-                }
+                disabled={filterEqual(emptyFilter, props.currentFilter)}
                 onClick={() => setSaveModalVisible(true)}
                 icon={<SaveOutlined />}>
                 Save...


### PR DESCRIPTION
Currently, to update a saved filter, the user has to clear existing
filters, enter in the filter parameters, click save, and then enter the
existing filter name to update it.

Changed the workflow such that the save button isn't disabled when an
existing filter is selected and convey the filtername to the save model.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/32