### PR TITLE
Simplify development setup for sapp

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -52,6 +52,9 @@
     {
       "site-package": "pyre_extensions"
     },
+    {
+      "site-package": "flask_cors"
+    },
     "stubs"
   ],
   "source_directories": [

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ $ source ~/.venvs/sapp/bin/activate
 (sapp) $ pip3 install -r requirements.txt
 ```
 
-Run the flask server:
+Run the flask server in debug mode:
 ```shell
-(sapp) $ python3 -m sapp.cli server
+(sapp) $ python3 -m sapp.cli server --debug
 ```
 
 Parse static analysis output and save to disk:
@@ -269,17 +269,21 @@ Parse static analysis output and save to disk:
 (sapp) $ python3 -m sapp.cli analyze taint-output.json
 ```
 
-If you make any changes to files under `sapp/ui/frontend/*`, you will need to run `npm install` once to install dependencies and `npm run-script build` each time you make changes before running the flask server to see the changes you made reflected:
-
-Installing dependencies:
+Installing dependencies for frontend:
 ```shell
 (sapp) $ cd sapp/ui/frontend && npm install
 ```
 
-Build static files and run the flask server:
+To interface sapp through the UI, we need to run both the frontend
+and backend simultaneously. In a production environment they run
+in the same port (because we serve the compilled version of frontend
+through the flask app in production). But in a development environment,
+the frontend runs in port 3000 and the backend runs in port 5000.
+
+Run the flask server and react app in development mode:
 ```shell
-(sapp) $ cd sapp/ui/frontend && npm run-script build
 (sapp) $ python3 -m sapp.cli server --debug
+(sapp) $ cd sapp/ui/frontend && npm run-script start
 ```
 
 ## FAQ

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 click-log
 flask
 flask_graphql
+flask-cors
 graphene==2.1.3
 graphene_sqlalchemy
 ipython

--- a/sapp/ui/frontend/src/index.js
+++ b/sapp/ui/frontend/src/index.js
@@ -27,8 +27,12 @@ import 'antd/dist/antd.css';
 const {Header, Content, Footer} = Layout;
 const {Text} = Typography;
 
+let uri = '/graphql';
+if (process.env.NODE_ENV === "development") {
+  uri = 'http://localhost:5000/graphql';
+}
 const client = new ApolloClient({
-  uri: '/graphql',
+  uri: uri,
   cache: new InMemoryCache(),
 });
 

--- a/sapp/ui/server.py
+++ b/sapp/ui/server.py
@@ -12,6 +12,7 @@ from typing import Optional
 import sqlalchemy
 from flask import Flask, send_from_directory
 from flask.wrappers import Response
+from flask_cors import CORS
 from flask_graphql import GraphQLView
 from pyre_extensions import none_throws
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
@@ -88,4 +89,6 @@ def start_server(
     )
     if static_resources:
         application.static_folder = static_resources
+    if debug:
+        CORS(application, resources={r"/graphql": {"origins": "http://localhost:3000"}})
     application.run(debug=debug, host="localhost", port=5000)


### PR DESCRIPTION
Currently, we need to rebuild the react app each time when we make any
changes to the UI and hot-reload is unavialable. Changes that by
introducing hot-reload by running the app on 3000 port and the flask
server on port 5000 so that hot-reload is available for both the
frontend and backend.

Adds CORS headers for the same to enable communication between both
frontend and backend using flask-cors library while on debug
(development) mode. Also adds flask-cors to requirements.txt

Updates the docs to specify the same.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/41