### PR TITLE
Support regex matching for source and sink filters

### DIFF
--- a/sapp/filter.py
+++ b/sapp/filter.py
@@ -10,14 +10,24 @@ from __future__ import annotations
 import json
 from json import JSONEncoder
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 from sqlalchemy import Column, String
 
 from .models import Base
 
 if TYPE_CHECKING:
-    from .ui.schema import FeatureCondition
+    from .ui.schema import FeatureCondition, MatchesIsField
+
+
+class NewMatchesIsAlias(TypedDict):
+    operation: str
+    value: List[str]
+
+
+# Previously the field contained values in form of a list, maintain Union for
+# backward compatibility.
+MatchesIsAlias = Union[NewMatchesIsAlias, List[str]]
 
 
 class FilterRecord(Base):
@@ -44,12 +54,12 @@ class Filter:
         )
         self.codes: List[int] = kwargs.get("codes", [])
         self.paths: List[str] = kwargs.get("paths", [])
-        self.callables: List[str] = kwargs.get("callables", [])
+        self.callables: MatchesIsAlias = kwargs.get("callables", [])
         self.statuses: List[str] = kwargs.get("statuses", [])
-        self.source_names: List[str] = kwargs.get("source_names", [])
-        self.source_kinds: List[str] = kwargs.get("source_kinds", [])
-        self.sink_names: List[str] = kwargs.get("sink_names", [])
-        self.sink_kinds: List[str] = kwargs.get("sink_kinds", [])
+        self.source_names: MatchesIsAlias = kwargs.get("source_names", [])
+        self.source_kinds: MatchesIsAlias = kwargs.get("source_kinds", [])
+        self.sink_names: MatchesIsAlias = kwargs.get("sink_names", [])
+        self.sink_kinds: MatchesIsAlias = kwargs.get("sink_kinds", [])
         self.traceLengthFromSources: Optional[List[int]] = kwargs.get(
             "traceLengthFromSources", None
         )
@@ -92,12 +102,12 @@ class Filter:
     def from_query(
         codes: List[int],
         paths: List[str],
-        callables: List[str],
+        callables: Optional[MatchesIsField],
         statuses: List[str],
-        source_names: List[str],
-        source_kinds: List[str],
-        sink_names: List[str],
-        sink_kinds: List[str],
+        source_names: Optional[MatchesIsField],
+        source_kinds: Optional[MatchesIsField],
+        sink_names: Optional[MatchesIsField],
+        sink_kinds: Optional[MatchesIsField],
         features: Optional[List[FeatureCondition]],
         min_trace_length_to_sinks: Optional[int],
         max_trace_length_to_sinks: Optional[int],

--- a/sapp/tests/fake_object_generator.py
+++ b/sapp/tests/fake_object_generator.py
@@ -196,6 +196,9 @@ class FakeObjectGenerator:
     def source(self, name="source"):
         return self.shared_text(contents=name, kind=SharedTextKind.SOURCE)
 
+    def source_detail(self, name="source_detail"):
+        return self.shared_text(contents=name, kind=SharedTextKind.SOURCE_DETAIL)
+
     def sink(self, name="sink"):
         return self.shared_text(contents=name, kind=SharedTextKind.SINK)
 

--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -195,31 +195,37 @@ const MatchesIsField = (
     setCurrentFilter: FilterDescription => void,
   }>,
 ): React$Node => {
-  const [mode, setMode] = useState('is');
-  const [inputValue, setInputValue] = useState(null);
+  const [inputValue, setInputValue] = useState('');
+  const [selectValue, setSelectValue] = useState([]);
+  const [matchedValues, setMatchedValues] = useState([]);
+
+  const triggerChange = (operation: string, value: mixed = undefined): void => {
+    let values = {};
+    if(value === undefined) {
+      value = (operation === 'is') ? selectValue : inputValue;
+    }
+    values[props.parameterName] = {
+      operation: operation,
+      value: value,
+    };
+    props.setCurrentFilter({...props.currentFilter, ...values});
+  }
+
+  const selectedOperation =
+    props.currentFilter[props.parameterName]?.operation || 'is';
 
   return (
     <Row gutter={gutter}>
       <Col span={6}>
         <Select
           options={[{value: 'is'}, {value: 'matches'}]}
-          value={mode}
-          onChange={setMode}
+          value={selectedOperation}
+          onChange={triggerChange}
           style={{width: '100%'}}
         />
       </Col>
       <Col span={16}>
-        {mode === 'is' ? (
-          <Select
-            mode="multiple"
-            value={props.currentFilter[props.parameterName]}
-            options={props.allOptions.map(value => ({value}))}
-            style={{width: '100%'}}
-            onChange={value =>
-              props.setCurrentFilter({...props.currentFilter, value})
-            }
-          />
-        ): (
+        {selectedOperation === 'matches' ? (
           <Input
             placeholder="regular expression"
             style={{width: '100%'}}
@@ -230,19 +236,29 @@ const MatchesIsField = (
               const option_values = props.allOptions.filter(option =>
                   option.match(value),
               );
-              let values = {};
-              values[props.parameterName] = option_values;
-              props.setCurrentFilter({...props.currentFilter, ...values});
+              setMatchedValues(option_values);
+              triggerChange('matches', value);
             }}
             suffix={
               <Tooltip
-                title={(props.currentFilter[props.parameterName] || []).join('\n')}
+                title={(matchedValues || []).join('\n')}
                 placement="bottom">
                 <Text type="secondary" size="small">
-                  {(props.currentFilter[props.parameterName] || []).length}
+                  {(matchedValues || []).length}
                 </Text>
               </Tooltip>
             }
+          />
+        ): (
+          <Select
+            mode="multiple"
+            value={selectValue}
+            options={props.allOptions.map(value => ({value}))}
+            style={{width: '100%'}}
+            onChange={value => {
+              setSelectValue(value);
+              triggerChange('is', value);
+            }}
           />
         )}
       </Col>

--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -187,6 +187,69 @@ const Paths = (
   );
 };
 
+const MatchesIsField = (
+  props: $ReadOnly<{
+    allOptions: $ReadOnlyList<string>,
+    parameterName: string,
+    currentFilter: FilterDescription,
+    setCurrentFilter: FilterDescription => void,
+  }>,
+): React$Node => {
+  const [mode, setMode] = useState('is');
+  const [inputValue, setInputValue] = useState(null);
+
+  return (
+    <Row gutter={gutter}>
+      <Col span={6}>
+        <Select
+          options={[{value: 'is'}, {value: 'matches'}]}
+          value={mode}
+          onChange={setMode}
+          style={{width: '100%'}}
+        />
+      </Col>
+      <Col span={16}>
+        {mode === 'is' ? (
+          <Select
+            mode="multiple"
+            value={props.currentFilter[props.parameterName]}
+            options={props.allOptions.map(value => ({value}))}
+            style={{width: '100%'}}
+            onChange={value =>
+              props.setCurrentFilter({...props.currentFilter, value})
+            }
+          />
+        ): (
+          <Input
+            placeholder="regular expression"
+            style={{width: '100%'}}
+            value={inputValue}
+            onChange={event => {
+              const value = event.target.value;
+              setInputValue(value);
+              const option_values = props.allOptions.filter(option =>
+                  option.match(value),
+              );
+              let values = {};
+              values[props.parameterName] = option_values;
+              props.setCurrentFilter({...props.currentFilter, ...values});
+            }}
+            suffix={
+              <Tooltip
+                title={(props.currentFilter[props.parameterName] || []).join('\n')}
+                placement="bottom">
+                <Text type="secondary" size="small">
+                  {(props.currentFilter[props.parameterName] || []).length}
+                </Text>
+              </Tooltip>
+            }
+          />
+        )}
+      </Col>
+    </Row>
+  );
+};
+
 const SourceNames = (
   props: $ReadOnly<{
     currentFilter: FilterDescription,
@@ -210,19 +273,12 @@ const SourceNames = (
   return (
     <>
       <Label label="name" />
-      <Row gutter={gutter}>
-        <Col span={22}>
-          <Select
-            mode="multiple"
-            value={props.currentFilter.source_names}
-            options={allSourceNames.map(value => ({value}))}
-            style={{width: '100%'}}
-            onChange={source_names =>
-              props.setCurrentFilter({...props.currentFilter, source_names})
-            }
-          />
-        </Col>
-      </Row>
+      <MatchesIsField
+        allOptions={allSourceNames}
+        currentFilter={props.currentFilter}
+        setCurrentFilter={props.setCurrentFilter}
+        parameterName="source_names"
+      />
     </>
   );
 };
@@ -250,19 +306,12 @@ const SourceKinds = (
   return (
     <>
       <Label label="kind" />
-      <Row gutter={gutter}>
-        <Col span={22}>
-          <Select
-            mode="multiple"
-            value={props.currentFilter.source_kinds}
-            options={allSourceKinds.map(value => ({value}))}
-            style={{width: '100%'}}
-            onChange={source_kinds =>
-              props.setCurrentFilter({...props.currentFilter, source_kinds})
-            }
-          />
-        </Col>
-      </Row>
+      <MatchesIsField
+        allOptions={allSourceKinds}
+        currentFilter={props.currentFilter}
+        setCurrentFilter={props.setCurrentFilter}
+        parameterName="source_kinds"
+      />
     </>
   );
 };
@@ -290,19 +339,12 @@ const SinkNames = (
   return (
     <>
       <Label label="name" />
-      <Row gutter={gutter}>
-        <Col span={22}>
-          <Select
-            mode="multiple"
-            value={props.currentFilter.sink_names}
-            options={allSinkNames.map(value => ({value}))}
-            style={{width: '100%'}}
-            onChange={sink_names =>
-              props.setCurrentFilter({...props.currentFilter, sink_names})
-            }
-          />
-        </Col>
-      </Row>
+      <MatchesIsField
+        allOptions={allSinkNames}
+        currentFilter={props.currentFilter}
+        setCurrentFilter={props.setCurrentFilter}
+        parameterName="sink_namess"
+      />
     </>
   );
 };
@@ -330,19 +372,12 @@ const SinkKinds = (
   return (
     <>
       <Label label="kind" />
-      <Row gutter={gutter}>
-        <Col span={22}>
-          <Select
-            mode="multiple"
-            value={props.currentFilter.sink_kinds}
-            options={allSinkKinds.map(value => ({value}))}
-            style={{width: '100%'}}
-            onChange={sink_kinds =>
-              props.setCurrentFilter({...props.currentFilter, sink_kinds})
-            }
-          />
-        </Col>
-      </Row>
+      <MatchesIsField
+        allOptions={allSinkKinds}
+        currentFilter={props.currentFilter}
+        setCurrentFilter={props.setCurrentFilter}
+        parameterName="sink_kinds"
+      />
     </>
   );
 };
@@ -399,9 +434,6 @@ const Callables = (
     setCurrentFilter: FilterDescription => void,
   }>,
 ): React$Node => {
-  const [mode, setMode] = useState('is');
-  const [inputValue, setInputValue] = useState(null);
-
   const callablesQuery = gql`
     query Callables {
       callables {
@@ -421,52 +453,12 @@ const Callables = (
   return (
     <>
       <Label label="callables" />
-      <Row gutter={gutter}>
-        <Col span={6}>
-          <Select
-            options={[{value: 'is'}, {value: 'matches'}]}
-            value={mode}
-            onChange={setMode}
-            style={{width: '100%'}}
-          />
-        </Col>
-        <Col span={16}>
-          {mode === 'is' ? (
-            <Select
-              mode="multiple"
-              value={props.currentFilter.callables}
-              options={allCallables.map(value => ({value}))}
-              style={{width: '100%'}}
-              onChange={callables =>
-                props.setCurrentFilter({...props.currentFilter, callables})
-              }
-            />
-          ) : (
-            <Input
-              placeholder="regular experssion"
-              style={{width: '100%'}}
-              value={inputValue}
-              onChange={event => {
-                const value = event.target.value;
-                setInputValue(value);
-                const callables = allCallables.filter(callable =>
-                  callable.match(value),
-                );
-                props.setCurrentFilter({...props.currentFilter, callables});
-              }}
-              suffix={
-                <Tooltip
-                  title={(props.currentFilter.callables || []).join('\n')}
-                  placement="bottom">
-                  <Text type="secondary" size="small">
-                    {(props.currentFilter.callables || []).length}
-                  </Text>
-                </Tooltip>
-              }
-            />
-          )}
-        </Col>
-      </Row>
+      <MatchesIsField
+        allOptions={allCallables}
+        currentFilter={props.currentFilter}
+        setCurrentFilter={props.setCurrentFilter}
+        parameterName="callables"
+      />
     </>
   );
 };

--- a/sapp/ui/frontend/src/Issues.js
+++ b/sapp/ui/frontend/src/Issues.js
@@ -48,11 +48,11 @@ export const IssueQuery = gql`
     $run_id: Int!
     $codes: [Int]
     $paths: [String]
-    $callables: [String]
-    $source_names: [String]
-    $source_kinds: [String]
-    $sink_names: [String]
-    $sink_kinds: [String]
+    $callables: MatchesIsField
+    $source_names: MatchesIsField
+    $source_kinds: MatchesIsField
+    $sink_names: MatchesIsField
+    $sink_kinds: MatchesIsField
     $statuses: [String]
     $features: [FeatureCondition]
     $min_trace_length_to_sinks: Int

--- a/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
@@ -715,6 +715,11 @@ Array [
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
+                    style={
+                      Object {
+                        "minWidth": "130px",
+                      }
+                    }
                   >
                     <div
                       className="ant-select-selector"

--- a/sapp/ui/issues.py
+++ b/sapp/ui/issues.py
@@ -428,6 +428,9 @@ class Instance:
     def where_callables_is_any_of(self, callables: List[str]) -> "Instance":
         return self.where(filter_predicates.Like(CallableText.contents, callables))
 
+    def where_callables_matches(self, regex: str) -> "Instance":
+        return self.where(filter_predicates.Matches(regex, "callable"))
+
     def where_status_is_any_of(self, statuses: List[str]) -> "Instance":
         return self.where(filter_predicates.Like(Issue.status, statuses))
 
@@ -437,14 +440,26 @@ class Instance:
     def where_source_name_is_any_of(self, source_names: List[str]) -> "Instance":
         return self.where(filter_predicates.HasAny(set(source_names), "source_names"))
 
+    def where_source_name_matches(self, regex: str) -> "Instance":
+        return self.where(filter_predicates.Matches(regex, "source_names"))
+
     def where_source_kind_is_any_of(self, source_kinds: List[str]) -> "Instance":
         return self.where(filter_predicates.HasAny(set(source_kinds), "source_kinds"))
+
+    def where_source_kind_matches(self, regex: str) -> "Instance":
+        return self.where(filter_predicates.Matches(regex, "source_kinds"))
 
     def where_sink_name_is_any_of(self, sink_names: List[str]) -> "Instance":
         return self.where(filter_predicates.HasAny(set(sink_names), "sink_names"))
 
+    def where_sink_name_matches(self, regex: str) -> "Instance":
+        return self.where(filter_predicates.Matches(regex, "sink_names"))
+
     def where_sink_kind_is_any_of(self, sink_kinds: List[str]) -> "Instance":
         return self.where(filter_predicates.HasAny(set(sink_kinds), "sink_kinds"))
+
+    def where_sink_kind_matches(self, regex: str) -> "Instance":
+        return self.where(filter_predicates.Matches(regex, "sink_kinds"))
 
     def where_trace_length_to_sinks(
         self, minimum: Optional[int] = None, maximum: Optional[int] = None
@@ -476,7 +491,6 @@ class Instance:
 
         builder = (
             self.where_codes_is_any_of(filter_instance.codes)
-            .where_callables_is_any_of(filter_instance.callables)
             .where_path_is_any_of(filter_instance.paths)
             .where_trace_length_to_sinks(
                 min_trace_length_to_sinks, max_trace_length_to_sinks
@@ -488,26 +502,130 @@ class Instance:
             .where_status_is_any_of(filter_instance.statuses)
         )
 
-        if (
-            filter_instance.source_names is not None
-            and len(filter_instance.source_names) > 0
-        ):
-            builder = builder.where_source_name_is_any_of(filter_instance.source_names)
-        if (
-            filter_instance.source_kinds is not None
-            and len(filter_instance.source_kinds) > 0
-        ):
-            builder = builder.where_source_kind_is_any_of(filter_instance.source_kinds)
-        if (
-            filter_instance.sink_names is not None
-            and len(filter_instance.sink_names) > 0
-        ):
-            builder = builder.where_sink_name_is_any_of(filter_instance.sink_names)
-        if (
-            filter_instance.sink_kinds is not None
-            and len(filter_instance.sink_kinds) > 0
-        ):
-            builder = builder.where_sink_kind_is_any_of(filter_instance.sink_kinds)
+        if filter_instance.callables:
+            if not isinstance(filter_instance.callables, list):
+                # pyre-fixme[16]: `List` has no attribute 'get'
+                if filter_instance.callables.get("operation") == "matches":
+                    builder = builder.where_callables_matches(
+                        filter_instance.callables.get("value", [""])[0]
+                    )
+                elif filter_instance.callables.get("operation") == "is":
+                    if any(filter_instance.callables.get("value", [])):
+                        builder = builder.where_callables_is_any_of(
+                            filter_instance.callables.get("value")
+                        )
+                else:
+                    raise ValueError(
+                        """Invalid value supplied for callables parameter
+                        `operation`. The supported values are `is` and
+                        `matches`."""
+                    )
+            else:
+                # Backward compatibility
+                # pyre-fixme[6]: Expected `List[str]` for 1st positional only
+                # parameter but got
+                # `Union[Dict[str, Union[List[str], str]], List[str]]`
+                builder = builder.where_callables_is_any_of(filter_instance.callables)
+
+        if filter_instance.source_names:
+            if not isinstance(filter_instance.source_names, list):
+                if filter_instance.source_names.get("operation") == "matches":
+                    builder = builder.where_source_name_matches(
+                        filter_instance.source_names.get("value", [""])[0]
+                    )
+                elif filter_instance.source_names.get("operation") == "is":
+                    if any(filter_instance.source_names.get("value", [])):
+                        builder = builder.where_source_name_is_any_of(
+                            filter_instance.source_names.get("value")
+                        )
+                else:
+                    raise ValueError(
+                        """Invalid value supplied for source_names parameter
+                        `operation`. The supported values are `is` and
+                        `matches`."""
+                    )
+            else:
+                # Backward compatibility
+                builder = builder.where_source_name_is_any_of(
+                    # pyre-fixme[6]: Expected `List[str]` for 1st positional only
+                    # parameter but got
+                    # `Union[Dict[str, Union[List[str], str]], List[str]]`
+                    filter_instance.source_names
+                )
+
+        if filter_instance.source_kinds:
+            if not isinstance(filter_instance.source_kinds, list):
+                if filter_instance.source_kinds.get("operation") == "matches":
+                    builder = builder.where_source_kind_matches(
+                        filter_instance.source_kinds.get("value", [""])[0]
+                    )
+                elif filter_instance.source_kinds.get("operation") == "is":
+                    if any(filter_instance.source_kinds.get("value", [])):
+                        builder = builder.where_source_kind_is_any_of(
+                            filter_instance.source_kinds.get("value")
+                        )
+                else:
+                    raise ValueError(
+                        """Invalid value supplied for source_kinds parameter
+                        `operation`. The supported values are `is` and
+                        `matches`."""
+                    )
+            else:
+                # Backward compatibility
+                builder = builder.where_source_kind_is_any_of(
+                    # pyre-fixme[6]: Expected `List[str]` for 1st positional only
+                    # parameter but got
+                    # `Union[Dict[str, Union[List[str], str]], List[str]]`
+                    filter_instance.source_kinds
+                )
+
+        if filter_instance.sink_names:
+            if not isinstance(filter_instance.sink_names, list):
+                if filter_instance.sink_names.get("operation") == "matches":
+                    builder = builder.where_sink_name_matches(
+                        filter_instance.sink_names.get("value", [""])[0]
+                    )
+                elif filter_instance.sink_names.get("operation") == "is":
+                    if any(filter_instance.sink_names.get("value", [])):
+                        builder = builder.where_sink_name_is_any_of(
+                            filter_instance.sink_names.get("value")
+                        )
+                else:
+                    raise ValueError(
+                        """Invalid value supplied for sink_names parameter
+                        `operation`. The supported values are `is` and
+                        `matches`."""
+                    )
+            else:
+                # Backward compatibility
+                # pyre-fixme[6]: Expected `List[str]` for 1st positional only
+                # parameter but got
+                # `Union[Dict[str, Union[List[str], str]], List[str]]`
+                builder = builder.where_sink_name_is_any_of(filter_instance.sink_names)
+
+        if filter_instance.sink_kinds:
+            if not isinstance(filter_instance.sink_kinds, list):
+                if filter_instance.sink_kinds.get("operation") == "matches":
+                    builder = builder.where_sink_kind_matches(
+                        filter_instance.sink_kinds.get("value", [""])[0]
+                    )
+                elif filter_instance.sink_kinds.get("operation") == "is":
+                    if any(filter_instance.sink_kinds.get("value", [])):
+                        builder = builder.where_sink_kind_is_any_of(
+                            filter_instance.sink_kinds.get("value")
+                        )
+                else:
+                    raise ValueError(
+                        """Invalid value supplied for sink_kinds parameter
+                        `operation`. The supported values are `is` and
+                        `matches`."""
+                    )
+            else:
+                # Backward compatibility if the filter is of the form List[str]
+                # pyre-fixme[6]: Expected `List[str]` for 1st positional only
+                # parameter but got
+                # `Union[Dict[str, Union[List[str], str]], List[str]]`
+                builder = builder.where_sink_kind_is_any_of(filter_instance.sink_kinds)
 
         for feature in filter_instance.format_features_for_query() or []:
             if feature[0] == "any of":

--- a/sapp/ui/schema.py
+++ b/sapp/ui/schema.py
@@ -104,6 +104,11 @@ class FeatureCondition(graphene.InputObjectType):
     features = graphene.List(graphene.String)
 
 
+class MatchesIsField(graphene.InputObjectType):
+    operation = graphene.String()
+    value = graphene.List(graphene.String)
+
+
 class Query(graphene.ObjectType):
     # pyre-fixme[4]: Attribute must be annotated.
     node = relay.Node.Field()
@@ -117,11 +122,11 @@ class Query(graphene.ObjectType):
         run_id=graphene.Int(required=True),
         codes=graphene.List(graphene.Int, default_value=["%"]),
         paths=graphene.List(graphene.String, default_value=["%"]),
-        callables=graphene.List(graphene.String, default_value=["%"]),
-        source_names=graphene.List(graphene.String),
-        source_kinds=graphene.List(graphene.String),
-        sink_names=graphene.List(graphene.String),
-        sink_kinds=graphene.List(graphene.String),
+        callables=MatchesIsField(),
+        source_names=MatchesIsField(),
+        source_kinds=MatchesIsField(),
+        sink_names=MatchesIsField(),
+        sink_kinds=MatchesIsField(),
         statuses=graphene.List(graphene.String, default_value=["%"]),
         features=graphene.List(FeatureCondition),
         min_trace_length_to_sinks=graphene.Int(),
@@ -168,8 +173,8 @@ class Query(graphene.ObjectType):
         run_id: int,
         codes: List[int],
         paths: List[str],
-        callables: List[str],
         statuses: List[str],
+        callables: Optional[MatchesIsField] = None,
         features: Optional[List[FeatureCondition]] = None,
         min_trace_length_to_sinks: Optional[int] = None,
         max_trace_length_to_sinks: Optional[int] = None,
@@ -177,10 +182,10 @@ class Query(graphene.ObjectType):
         max_trace_length_to_sources: Optional[int] = None,
         issue_instance_id: Optional[int] = None,
         is_new_issue: Optional[bool] = None,
-        source_names: Optional[List[str]] = None,
-        source_kinds: Optional[List[str]] = None,
-        sink_names: Optional[List[str]] = None,
-        sink_kinds: Optional[List[str]] = None,
+        source_names: Optional[MatchesIsField] = None,
+        source_kinds: Optional[MatchesIsField] = None,
+        sink_names: Optional[MatchesIsField] = None,
+        sink_kinds: Optional[MatchesIsField] = None,
         **kwargs: Any,
     ) -> List[IssueQueryResult]:
         session = get_session(info.context)
@@ -190,16 +195,9 @@ class Query(graphene.ObjectType):
             paths,
             callables,
             statuses,
-            # pyre-ignore[6]: Optional, Final doesn't work
             source_names,
-            # pyre-fixme[6]: Expected `List[str]` for 6th param but got
-            #  `Optional[List[str]]`.
             source_kinds,
-            # pyre-fixme[6]: Expected `List[str]` for 7th param but got
-            #  `Optional[List[str]]`.
             sink_names,
-            # pyre-fixme[6]: Expected `List[str]` for 8th param but got
-            #  `Optional[List[str]]`.
             sink_kinds,
             features,
             min_trace_length_to_sinks,

--- a/sapp/ui/tests/issues_test.py
+++ b/sapp/ui/tests/issues_test.py
@@ -123,7 +123,7 @@ class QueryTest(TestCase):
             builder = Instance(session, latest_run_id)
             issue_ids = {
                 int(issue.issue_instance_id)
-                for issue in builder.where_callables_is_any_of(["%sub%"]).get()
+                for issue in builder.where_callables_matches(".*sub.*").get()
             }
             self.assertIn(1, issue_ids)
             self.assertIn(2, issue_ids)
@@ -141,7 +141,7 @@ class QueryTest(TestCase):
             builder = Instance(session, latest_run_id)
             issue_ids = {
                 int(issue.issue_instance_id)
-                for issue in builder.where_callables_is_any_of(["%function3"]).get()
+                for issue in builder.where_callables_matches(".*function3").get()
             }
             self.assertNotIn(1, issue_ids)
             self.assertNotIn(2, issue_ids)
@@ -287,6 +287,226 @@ class QueryTest(TestCase):
             self.assertNotIn(2, issue_ids)
             self.assertNotIn(3, issue_ids)
             self.assertIn(4, issue_ids)
+
+    def testWhereSourceName(self) -> None:
+        self.fakes.instance()
+        source_name_1 = self.fakes.source_detail("source_name_1")
+        source_name_2 = self.fakes.source_detail("source_name_2")
+
+        self.fakes.save_all(self.db)
+
+        with self.db.make_session() as session:
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=source_name_1.id, issue_instance_id=1
+                )
+            )
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=source_name_2.id, issue_instance_id=2
+                )
+            )
+            session.commit()
+            latest_run_id = queries.latest_run_id(session)
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_name_is_any_of(
+                    ["source_name_1"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_name_matches("source_name_1").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_name_is_any_of(
+                    ["source_name_1", "source_name_2"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_name_matches("source_name").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+    def testWhereSourceKind(self) -> None:
+        self.fakes.instance()
+        source_kind_1 = self.fakes.source("source_kind_1")
+        source_kind_2 = self.fakes.source("source_kind_2")
+
+        self.fakes.save_all(self.db)
+
+        with self.db.make_session() as session:
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=source_kind_1.id, issue_instance_id=1
+                )
+            )
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=source_kind_2.id, issue_instance_id=2
+                )
+            )
+            session.commit()
+            latest_run_id = queries.latest_run_id(session)
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_kind_is_any_of(
+                    ["source_kind_1"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_kind_matches("source_kind_1").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_kind_is_any_of(
+                    ["source_kind_1", "source_kind_2"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_source_kind_matches("source_kind").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+    def testWhereSinkName(self) -> None:
+        self.fakes.instance()
+        sink_name_1 = self.fakes.sink_detail("sink_name_1")
+        sink_name_2 = self.fakes.sink_detail("sink_name_2")
+
+        self.fakes.save_all(self.db)
+
+        with self.db.make_session() as session:
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=sink_name_1.id, issue_instance_id=1
+                )
+            )
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=sink_name_2.id, issue_instance_id=2
+                )
+            )
+            session.commit()
+            latest_run_id = queries.latest_run_id(session)
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_name_is_any_of(["sink_name_1"]).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_name_matches("sink_name_1").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_name_is_any_of(
+                    ["sink_name_1", "sink_name_2"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_name_matches("sink_name").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+    def testWhereSinkKind(self) -> None:
+        self.fakes.instance()
+        sink_kind_1 = self.fakes.sink("sink_kind_1")
+        sink_kind_2 = self.fakes.sink("sink_kind_2")
+
+        self.fakes.save_all(self.db)
+
+        with self.db.make_session() as session:
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=sink_kind_1.id, issue_instance_id=1
+                )
+            )
+            session.add(
+                IssueInstanceSharedTextAssoc(
+                    shared_text_id=sink_kind_2.id, issue_instance_id=2
+                )
+            )
+            session.commit()
+            latest_run_id = queries.latest_run_id(session)
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_kind_is_any_of(["sink_kind_1"]).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_kind_matches("sink_kind_1").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertNotIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_kind_is_any_of(
+                    ["sink_kind_1", "sink_kind_2"]
+                ).get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
+
+            builder = Instance(session, latest_run_id)
+            issue_ids = {
+                int(issue.issue_instance_id)
+                for issue in builder.where_sink_kind_matches("sink_kind").get()
+            }
+            self.assertIn(1, issue_ids)
+            self.assertIn(2, issue_ids)
 
     def testWhereAnyFeatures(self) -> None:
         self.fakes.instance()


### PR DESCRIPTION
Adds support for regex matching for source name and kind and sink name
and kind filters. The regex matching occurs in the frontend and no
modification is hence required in the backend.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/46