### PR TITLE
Add Jest tests to test ReactJS frontend

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,22 @@
+name: jest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies and run Jest
+        run: |
+          cd sapp/ui/frontend
+          npm install
+          npm run-script ui-test

--- a/sapp/ui/frontend/package-lock.json
+++ b/sapp/ui/frontend/package-lock.json
@@ -63,6 +63,7 @@
         "react-dev-utils": "^11.0.4",
         "react-dom": "^16.13.1",
         "react-router-dom": "^5.2.0",
+        "react-test-renderer": "^16.14.0",
         "resolve": "1.15.0",
         "resolve-url-loader": "^3.1.2",
         "sass-loader": "8.0.2",
@@ -129,23 +130,41 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.0.2.tgz",
-      "integrity": "sha512-4ighan5Anlj4tK/tdUHs4Mi1njqXZ7AxRCVolz/H702DjPphAJfm+FRkIadPTmwz+OLO+d+tX+6V1VBshf02rg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.7.tgz",
+      "integrity": "sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==",
       "dependencies": {
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.1.9",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.10.4",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
+        "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
-        "symbol-observable": "^1.2.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.1.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@apollo/client/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/@apollo/react-hoc": {
       "version": "4.0.0",
@@ -154,38 +173,6 @@
       "dependencies": {
         "@apollo/client": "^3.1.2"
       }
-    },
-    "node_modules/@apollo/react-hoc/node_modules/@apollo/client": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.1.2.tgz",
-      "integrity": "sha512-GaA/J0CDSSNe0HVm1abeOIJA3M4fs9Ih7wF2z1AI2SLqv5TBLvwBxh0+0+jCSntPZ3gnDQvR7MHjmXota5V1LQ==",
-      "dependencies": {
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.11.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^1.2.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
-      }
-    },
-    "node_modules/@apollo/react-hoc/node_modules/@wry/equality": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "node_modules/@apollo/react-hoc/node_modules/graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -1334,6 +1321,14 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -2081,9 +2076,9 @@
       "integrity": "sha1-yz+fdBhp4gzOMw/765JxWQSDiC0="
     },
     "node_modules/@types/zen-observable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -2296,20 +2291,52 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-      "integrity": "sha1-8qXVq5InNDqnTIHgZTPB74RZjsc=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "node_modules/@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/@wry/equality/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -6402,9 +6429,23 @@
       "integrity": "sha1-OtKwyqsNEQ475KWpsqooHjYrUng="
     },
     "node_modules/graphql-tag": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
-      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -9057,11 +9098,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
-      "integrity": "sha1-kz+UZ7mu8OYBZVrbljj4k+SGrQI=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "dependencies": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
@@ -10962,13 +11004,16 @@
       }
     },
     "node_modules/react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-app-polyfill": {
@@ -11217,6 +11262,20 @@
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dependencies": {
         "isarray": "0.0.1"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
       }
     },
     "node_modules/read-pkg": {
@@ -12739,9 +12798,12 @@
       }
     },
     "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -13067,12 +13129,20 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha1-l6UjUYaI+TqvrQGw6A64A+sqvYY=",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.1.tgz",
+      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/ts-invariant/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/ts-pnp": {
       "version": "1.1.6",
@@ -14293,6 +14363,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha1-lkFcUS2OP/2SCv04iWBOMLnqrBU="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     }
   },
   "dependencies": {
@@ -14350,22 +14429,29 @@
       }
     },
     "@apollo/client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.0.2.tgz",
-      "integrity": "sha512-4ighan5Anlj4tK/tdUHs4Mi1njqXZ7AxRCVolz/H702DjPphAJfm+FRkIadPTmwz+OLO+d+tX+6V1VBshf02rg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.7.tgz",
+      "integrity": "sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==",
       "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.1.9",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.10.4",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
+        "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
-        "symbol-observable": "^1.2.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@apollo/react-hoc": {
@@ -14374,40 +14460,6 @@
       "integrity": "sha1-ZLVNmt9Vi5/coSFeZhc2rK1CbgU=",
       "requires": {
         "@apollo/client": "^3.1.2"
-      },
-      "dependencies": {
-        "@apollo/client": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.1.2.tgz",
-          "integrity": "sha512-GaA/J0CDSSNe0HVm1abeOIJA3M4fs9Ih7wF2z1AI2SLqv5TBLvwBxh0+0+jCSntPZ3gnDQvR7MHjmXota5V1LQ==",
-          "requires": {
-            "@types/zen-observable": "^0.8.0",
-            "@wry/context": "^0.5.2",
-            "@wry/equality": "^0.2.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-tag": "^2.11.0",
-            "hoist-non-react-statics": "^3.3.2",
-            "optimism": "^0.12.1",
-            "prop-types": "^15.7.2",
-            "symbol-observable": "^1.2.0",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0",
-            "zen-observable": "^0.8.14"
-          }
-        },
-        "@wry/equality": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
-        "graphql-tag": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-          "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
-        }
       }
     },
     "@babel/code-frame": {
@@ -15567,6 +15619,12 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "requires": {}
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -16314,9 +16372,9 @@
       "integrity": "sha1-yz+fdBhp4gzOMw/765JxWQSDiC0="
     },
     "@types/zen-observable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -16531,19 +16589,48 @@
       }
     },
     "@wry/context": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-      "integrity": "sha1-8qXVq5InNDqnTIHgZTPB74RZjsc=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -20686,9 +20773,19 @@
       "integrity": "sha1-OtKwyqsNEQ475KWpsqooHjYrUng="
     },
     "graphql-tag": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
-      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -23383,11 +23480,12 @@
       }
     },
     "optimism": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
-      "integrity": "sha1-kz+UZ7mu8OYBZVrbljj4k+SGrQI=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "requires": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -25318,9 +25416,9 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -25543,6 +25641,17 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
       }
     },
     "read-pkg": {
@@ -27092,9 +27201,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -27428,11 +27537,18 @@
       }
     },
     "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha1-l6UjUYaI+TqvrQGw6A64A+sqvYY=",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.1.tgz",
+      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "ts-pnp": {
@@ -28676,6 +28792,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha1-lkFcUS2OP/2SCv04iWBOMLnqrBU="
+    },
+    "zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "requires": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     }
   }
 }

--- a/sapp/ui/frontend/package.json
+++ b/sapp/ui/frontend/package.json
@@ -59,6 +59,7 @@
     "react-dev-utils": "^11.0.4",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
+    "react-test-renderer": "^16.14.0",
     "resolve": "1.15.0",
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "8.0.2",
@@ -76,6 +77,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
+    "ui-test": "node node_modules/jest/bin/jest.js",
     "flow": "flow",
     "lint": "npx eslint . --max-warnings=0"
   },
@@ -125,7 +127,8 @@
     },
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$",
-      "^.+\\.module\\.(css|sass|scss)$"
+      "^.+\\.module\\.(css|sass|scss)$",
+      "/node_modules/(?!antd|@ant-design|rc-.+?|@babel/runtime).+(js|jsx)$"
     ],
     "modulePaths": [],
     "moduleNameMapper": {

--- a/sapp/ui/frontend/src/Filter.js
+++ b/sapp/ui/frontend/src/Filter.js
@@ -877,6 +877,20 @@ function getRecentFilters(): mixed {
   return [];
 }
 
+export const filtersQuery = gql`
+  query Filters {
+    filters {
+      edges {
+        node {
+          name
+          description
+          json
+        }
+      }
+    }
+  }
+`;
+
 export const FilterControls = (props: {
   refetch: mixed => mixed,
   refetching: boolean,
@@ -901,19 +915,6 @@ export const FilterControls = (props: {
     );
   });
 
-  const filtersQuery = gql`
-    query Filters {
-      filters {
-        edges {
-          node {
-            name
-            description
-            json
-          }
-        }
-      }
-    }
-  `;
   const {
     loading: filterLoading,
     error: filterError,

--- a/sapp/ui/frontend/src/Issues.js
+++ b/sapp/ui/frontend/src/Issues.js
@@ -42,7 +42,7 @@ function IssuesList(props: $ReadOnly<{|
 
 const PAGE_SIZE = 20;
 
-const IssueQuery = gql`
+export const IssueQuery = gql`
   query Issue(
     $after: String
     $run_id: Int!

--- a/sapp/ui/frontend/src/Issues.test.js
+++ b/sapp/ui/frontend/src/Issues.test.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { MockedProvider } from '@apollo/client/testing';
+import Issues, { IssueQuery } from './Issues';
+import { Issue, IssueSkeleton } from './Issue';
+import FilterControls, { filtersQuery } from './Filter';
+
+const {act} = TestRenderer;
+
+test("Renders issues and filters", async () => {
+  // Mock window.matchMedia
+  window.matchMedia = window.matchMedia || function() {
+    return {
+      matches: false,
+      addListener: function() {},
+      removeListener: function() {}
+    };
+  };
+
+  const mockIssues = {
+    edges: [{
+      node: {
+        issue_id: "1",
+        issue_instance_id: "11",
+        code: 6065,
+        message: "This is a test issue",
+        callable: "run.test",
+        filename: "tests.js",
+        location: "26|11|12",
+        sources: ["TestSource"],
+        source_names: ["TestSource"],
+        sinks: ["TestSink"],
+        sink_names: ["TestSink"],
+        status: "Uncategorized",
+        features: ["always-via:test"],
+        is_new_issue: false,
+        min_trace_length_to_sources: 0,
+        min_trace_length_to_sinks: 0,
+      },
+    }],
+    pageInfo: {
+      endCursor: "TestCursor",
+    },
+  };
+
+  /**
+   * There are only 2 requests, but one of the requests sometimes
+   * occur with varrying variables, hence for issues, we have
+   * two requests, and one for filters making total of 3 mocks
+   */
+  const mocks = [{
+    request: {
+      query: IssueQuery,
+      variables: {
+        run_id: "0",
+        offset:0,
+      },
+    },
+    result: {
+      data: {
+        issues: mockIssues,
+      },
+    },
+  },
+  {
+    request: {
+      query: IssueQuery,
+      variables: {
+        run_id: "0",
+        features: [{mode:"all of",features:[]}],
+        min_trace_length_to_sources: undefined,
+        max_trace_length_to_sources: undefined,
+        min_trace_length_to_sinks: undefined,
+        max_trace_length_to_sinks: undefined,
+        offset:0,
+      },
+    },
+    result: {
+      data: {
+        issues: mockIssues,
+      },
+    },
+  },
+  {
+    request: {
+      query: filtersQuery,
+    },
+    result: {
+      data: {
+        filters: {
+          edges: [{
+            node: {
+              name: "Test Filter",
+              description: "Test description",
+              json: "{}",
+            },
+          }],
+        },
+      },
+    },
+  }];
+
+  const match = {
+    params: {
+      run_id: "0",
+    },
+  };
+
+  const component = TestRenderer.create(
+    <MockedProvider mocks={mocks}>
+      <Issues match={match}/>
+    </MockedProvider>
+  );
+
+  // Mocked provider hasn't populated the results yet. Use it to test loading
+  let tree = component.toJSON();
+  expect(tree[1].children.join('')).toContain(
+    TestRenderer.create(<IssueSkeleton/>)
+  );
+  expect(tree).toMatchSnapshot();
+
+  /**
+   * Await a zero-millisecond timeout. This delays the checks until the next
+   * "tick" of the event loop, which gives MockedProvider an opportunity to
+   * populate the mocked result. Await two ticks because there are two
+   * `useQuery` functions called in Issues.js. First tick renders the filters
+   * and the second tick renders the issue(s).
+   */
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  tree = component.toJSON();
+  const instance = component.root;
+  expect(instance.findByType(Issue).props.issue.callable).toBe('run.test');
+  expect(instance.findByType(FilterControls).props.refetching).toBe(false);
+  expect(tree).toMatchSnapshot();
+});

--- a/sapp/ui/frontend/src/Runs.js
+++ b/sapp/ui/frontend/src/Runs.js
@@ -103,20 +103,20 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
   );
 }
 
-export default function Runs(props: $ReadOnly<{}>): React$Node {
-  const RunsQuery = gql`
-    query Run {
-      runs {
-        edges {
-          node {
-            run_id
-            date
-          }
+export const RunsQuery = gql`
+  query Run {
+    runs {
+      edges {
+        node {
+          run_id
+          date
         }
       }
     }
-  `;
+  }
+`;
 
+export default function Runs(props: $ReadOnly<{}>): React$Node {
   const {loading, error, data} = useQuery(RunsQuery);
 
   if (error) {

--- a/sapp/ui/frontend/src/Runs.test.js
+++ b/sapp/ui/frontend/src/Runs.test.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { MockedProvider } from '@apollo/client/testing';
+import Runs, {RunsQuery} from './Runs';
+
+const {act} = TestRenderer;
+
+test("Renders runs", async () => {
+  // Mock window.matchMedia
+  window.matchMedia = window.matchMedia || function() {
+    return {
+      matches: false,
+      addListener: function() {},
+      removeListener: function() {}
+    };
+  };
+
+  const mock = {
+    request: {
+      query: RunsQuery,
+    },
+    result: {
+      data: {
+        runs: {
+          edges: [{
+            node: {
+              run_id: "1",
+              date: "Dummy date",
+            },
+          }],
+        },
+      },
+    },
+  };
+
+  const component = TestRenderer.create(
+    <MockedProvider mocks={[mock]}>
+      <Runs/>
+    </MockedProvider>
+  );
+
+  // Mocked provider hasn't populated the results yet. Use it to test loading
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  /**
+   * Await a zero-millisecond timeout. This delays the checks until the next
+   * "tick" of the event loop, which gives MockedProvider an opportunity to
+   * populate the mocked result
+   */
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  tree = component.toJSON();
+  expect(tree).toMatchSnapshot()
+});

--- a/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
@@ -1,0 +1,1557 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders issues and filters 1`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/runs"
+      >
+        Runs
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Run 
+        0
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <section
+    className="ant-layout ant-layout-has-sider"
+  >
+    <section
+      className="ant-layout"
+      style={
+        Object {
+          "paddingRight": "24px",
+        }
+      }
+    >
+      <div
+        className="ant-card ant-card-bordered"
+      >
+        <div
+          className="ant-card-body"
+          style={Object {}}
+        >
+          <div
+            className="ant-skeleton ant-skeleton-active"
+          >
+            <div
+              className="ant-skeleton-content"
+            >
+              <h3
+                className="ant-skeleton-title"
+                style={
+                  Object {
+                    "width": "38%",
+                  }
+                }
+              />
+              <ul
+                className="ant-skeleton-paragraph"
+              >
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": undefined,
+                    }
+                  }
+                />
+                <li
+                  style={
+                    Object {
+                      "width": "61%",
+                    }
+                  }
+                />
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <aside
+      className="ant-layout-sider ant-layout-sider-dark"
+      style={
+        Object {
+          "flex": "0 0 300px",
+          "maxWidth": "300px",
+          "minWidth": "300px",
+          "width": "300px",
+        }
+      }
+    >
+      <div
+        className="ant-layout-sider-children"
+      >
+        <div
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <button
+            className="ant-btn"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="filter"
+              className="anticon anticon-filter"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="filter"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M880.1 154H143.9c-24.5 0-39.8 26.7-27.5 48L349 597.4V838c0 17.7 14.2 32 31.8 32h262.4c17.6 0 31.8-14.3 31.8-32V597.4L907.7 202c12.2-21.3-3.1-48-27.6-48zM603.4 798H420.6V642h182.9v156zm9.6-236.6l-9.5 16.6h-183l-9.5-16.6L212.7 226h598.6L613 561.4z"
+                />
+              </svg>
+            </span>
+            <span>
+              Filter...
+            </span>
+          </button>
+        </div>
+        <ul
+          className="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+          onMouseEnter={[Function]}
+          onTransitionEnd={[Function]}
+          role="menu"
+          style={
+            Object {
+              "borderRight": 0,
+            }
+          }
+        >
+          <div
+            className="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "padding": "12px 12px 0 12px",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className="ant-select-selector"
+              onMouseDown={[Function]}
+            >
+              <span
+                className="ant-select-selection-search"
+              >
+                <span
+                  className="ant-input-affix-wrapper ant-input-search ant-select-selection-search-input"
+                  onMouseUp={[Function]}
+                  style={
+                    Object {
+                      "opacity": null,
+                    }
+                  }
+                >
+                  <input
+                    aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="rc_select_TEST_OR_SSR_list"
+                    aria-haspopup="listbox"
+                    aria-owns="rc_select_TEST_OR_SSR_list"
+                    autoComplete="off"
+                    className="ant-input"
+                    id="rc_select_TEST_OR_SSR"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onCompositionEnd={[Function]}
+                    onCompositionStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onPaste={[Function]}
+                    placeholder="saved filter"
+                    readOnly={false}
+                    role="combobox"
+                    style={null}
+                    type="search"
+                    unselectable={null}
+                    value=""
+                  />
+                  <span
+                    className="ant-input-suffix"
+                  >
+                    <span
+                      aria-label="search"
+                      className="anticon anticon-search ant-input-search-icon"
+                      onClick={[Function]}
+                      role="img"
+                      tabIndex={-1}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className=""
+                        data-icon="search"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+          <li
+            className="ant-menu-submenu ant-menu-submenu-inline"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="menuitem"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup="true"
+              className="ant-menu-submenu-title"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              style={
+                Object {
+                  "paddingLeft": 24,
+                }
+              }
+            >
+              <span
+                aria-label="setting"
+                className="anticon anticon-setting"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="setting"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Filter options
+              </span>
+              <i
+                className="ant-menu-submenu-arrow"
+              />
+            </div>
+            <div />
+          </li>
+          <li
+            className="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open ant-menu-submenu-disabled"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="menuitem"
+          >
+            <div
+              aria-expanded={true}
+              aria-haspopup="true"
+              aria-owns="recents$Menu"
+              className="ant-menu-submenu-title"
+              role="button"
+              style={
+                Object {
+                  "paddingLeft": 24,
+                }
+              }
+            >
+              <span
+                aria-label="field-time"
+                className="anticon anticon-field-time"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="field-time"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <defs>
+                    <style />
+                  </defs>
+                  <path
+                    d="M945 412H689c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h256c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM811 548H689c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h122c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM477.3 322.5H434c-6.2 0-11.2 5-11.2 11.2v248c0 3.6 1.7 6.9 4.6 9l148.9 108.6c5 3.6 12 2.6 15.6-2.4l25.7-35.1v-.1c3.6-5 2.5-12-2.5-15.6l-126.7-91.6V333.7c.1-6.2-5-11.2-11.1-11.2z"
+                  />
+                  <path
+                    d="M804.8 673.9H747c-5.6 0-10.9 2.9-13.9 7.7a321 321 0 01-44.5 55.7 317.17 317.17 0 01-101.3 68.3c-39.3 16.6-81 25-124 25-43.1 0-84.8-8.4-124-25-37.9-16-72-39-101.3-68.3s-52.3-63.4-68.3-101.3c-16.6-39.2-25-80.9-25-124 0-43.1 8.4-84.7 25-124 16-37.9 39-72 68.3-101.3 29.3-29.3 63.4-52.3 101.3-68.3 39.2-16.6 81-25 124-25 43.1 0 84.8 8.4 124 25 37.9 16 72 39 101.3 68.3a321 321 0 0144.5 55.7c3 4.8 8.3 7.7 13.9 7.7h57.8c6.9 0 11.3-7.2 8.2-13.3-65.2-129.7-197.4-214-345-215.7-216.1-2.7-395.6 174.2-396 390.1C71.6 727.5 246.9 903 463.2 903c149.5 0 283.9-84.6 349.8-215.8a9.18 9.18 0 00-8.2-13.3z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Recent filters
+              </span>
+              <i
+                className="ant-menu-submenu-arrow"
+              />
+            </div>
+            <ul
+              className="ant-menu ant-menu-sub ant-menu-inline"
+              id="recents$Menu"
+              role="menu"
+              style={Object {}}
+            />
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </section>,
+]
+`;
+
+exports[`Renders issues and filters 2`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/runs"
+      >
+        Runs
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Run 
+        0
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <section
+    className="ant-layout ant-layout-has-sider"
+  >
+    <section
+      className="ant-layout"
+      style={
+        Object {
+          "paddingRight": "24px",
+        }
+      }
+    >
+      <div
+        className="ant-card ant-card-bordered ant-card-small"
+      >
+        <div
+          className="ant-card-head"
+          style={Object {}}
+        >
+          <div
+            className="ant-card-head-wrapper"
+          >
+            <div
+              className="ant-card-head-title"
+            >
+              <span
+                aria-label="fire"
+                className="anticon anticon-fire"
+                role="img"
+                style={
+                  Object {
+                    "marginRight": ".5em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="fire"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M834.1 469.2A347.49 347.49 0 00751.2 354l-29.1-26.7a8.09 8.09 0 00-13 3.3l-13 37.3c-8.1 23.4-23 47.3-44.1 70.8-1.4 1.5-3 1.9-4.1 2-1.1.1-2.8-.1-4.3-1.5-1.4-1.2-2.1-3-2-4.8 3.7-60.2-14.3-128.1-53.7-202C555.3 171 510 123.1 453.4 89.7l-41.3-24.3c-5.4-3.2-12.3 1-12 7.3l2.2 48c1.5 32.8-2.3 61.8-11.3 85.9-11 29.5-26.8 56.9-47 81.5a295.64 295.64 0 01-47.5 46.1 352.6 352.6 0 00-100.3 121.5A347.75 347.75 0 00160 610c0 47.2 9.3 92.9 27.7 136a349.4 349.4 0 0075.5 110.9c32.4 32 70 57.2 111.9 74.7C418.5 949.8 464.5 959 512 959s93.5-9.2 136.9-27.3A348.6 348.6 0 00760.8 857c32.4-32 57.8-69.4 75.5-110.9a344.2 344.2 0 0027.7-136c0-48.8-10-96.2-29.9-140.9zM713 808.5c-53.7 53.2-125 82.4-201 82.4s-147.3-29.2-201-82.4c-53.5-53.1-83-123.5-83-198.4 0-43.5 9.8-85.2 29.1-124 18.8-37.9 46.8-71.8 80.8-97.9a349.6 349.6 0 0058.6-56.8c25-30.5 44.6-64.5 58.2-101a240 240 0 0012.1-46.5c24.1 22.2 44.3 49 61.2 80.4 33.4 62.6 48.8 118.3 45.8 165.7a74.01 74.01 0 0024.4 59.8 73.36 73.36 0 0053.4 18.8c19.7-1 37.8-9.7 51-24.4 13.3-14.9 24.8-30.1 34.4-45.6 14 17.9 25.7 37.4 35 58.4 15.9 35.8 24 73.9 24 113.1 0 74.9-29.5 145.4-83 198.4z"
+                  />
+                </svg>
+              </span>
+              Issue 
+              1
+            </div>
+            <div
+              className="ant-card-extra"
+            >
+              <a
+                className="ant-typography"
+                href="/run/0/issue/11"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Traces
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ant-card-body"
+          style={Object {}}
+        >
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Code
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <code>
+                    6065
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Description
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                This is a test issue
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Status
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <div
+                    className="ant-select ant-select-sm ant-select-single ant-select-show-arrow"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                  >
+                    <div
+                      className="ant-select-selector"
+                      onMouseDown={[Function]}
+                    >
+                      <span
+                        className="ant-select-selection-search"
+                      >
+                        <input
+                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autoComplete="off"
+                          className="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          onChange={[Function]}
+                          onCompositionEnd={[Function]}
+                          onCompositionStart={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onPaste={[Function]}
+                          readOnly={true}
+                          role="combobox"
+                          style={
+                            Object {
+                              "opacity": 0,
+                            }
+                          }
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        className="ant-select-selection-item"
+                        title="Uncategorized"
+                      >
+                        Uncategorized
+                      </span>
+                    </div>
+                    <span
+                      aria-hidden={true}
+                      className="ant-select-arrow"
+                      onMouseDown={[Function]}
+                      style={
+                        Object {
+                          "WebkitUserSelect": "none",
+                          "userSelect": "none",
+                        }
+                      }
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        className="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className=""
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Callable
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                      "wordBreak": "break-all",
+                    }
+                  }
+                >
+                  <code>
+                    run.test
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Location
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  aria-label="code"
+                  className="anticon anticon-code"
+                  onClick={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onTouchStart={[Function]}
+                  role="img"
+                  tabIndex={-1}
+                >
+                  <svg
+                    aria-hidden="true"
+                    className=""
+                    data-icon="code"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+                      fill="#1890ff"
+                    />
+                    <path
+                      d="M184 840h656V184H184v656zm339.5-223h185c4.1 0 7.5 3.6 7.5 8v48c0 4.4-3.4 8-7.5 8h-185c-4.1 0-7.5-3.6-7.5-8v-48c0-4.4 3.4-8 7.5-8zM308 610.3c0-2.3 1.1-4.6 2.9-6.1L420.7 512l-109.8-92.2a7.63 7.63 0 01-2.9-6.1V351c0-6.8 7.9-10.5 13.1-6.1l192 160.9c3.9 3.2 3.9 9.1 0 12.3l-192 161c-5.2 4.4-13.1.7-13.1-6.1v-62.7z"
+                      fill="#e6f7ff"
+                    />
+                    <path
+                      d="M321.1 679.1l192-161c3.9-3.2 3.9-9.1 0-12.3l-192-160.9A7.95 7.95 0 00308 351v62.7c0 2.4 1 4.6 2.9 6.1L420.7 512l-109.8 92.2a8.1 8.1 0 00-2.9 6.1V673c0 6.8 7.9 10.5 13.1 6.1zM516 673c0 4.4 3.4 8 7.5 8h185c4.1 0 7.5-3.6 7.5-8v-48c0-4.4-3.4-8-7.5-8h-185c-4.1 0-7.5 3.6-7.5 8v48z"
+                      fill="#1890ff"
+                    />
+                  </svg>
+                </span>
+                 
+                <span
+                  className="ant-typography"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                      "wordBreak": "break-all",
+                    }
+                  }
+                >
+                  <code>
+                    tests.js
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Sources
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <span
+                    className="ant-tag ant-tag-green"
+                    style={
+                      Object {
+                        "backgroundColor": undefined,
+                      }
+                    }
+                  >
+                    TestSource
+                  </span>
+                </span>
+                 
+                at
+                 
+                <span
+                  className="ant-typography"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <u>
+                    minimum distance 
+                    0
+                    .
+                  </u>
+                </span>
+                <br />
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "marginTop": ".5em",
+                    }
+                  }
+                >
+                  <span
+                    className="ant-tag"
+                    style={
+                      Object {
+                        "backgroundColor": undefined,
+                      }
+                    }
+                  >
+                    TestSource
+                  </span>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Sinks
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <span
+                    className="ant-tag ant-tag-red"
+                    style={
+                      Object {
+                        "backgroundColor": undefined,
+                      }
+                    }
+                  >
+                    TestSink
+                  </span>
+                </span>
+                 
+                at
+                 
+                <span
+                  className="ant-typography"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <u>
+                    minimum distance 
+                    0
+                    .
+                  </u>
+                </span>
+                <br />
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "marginTop": ".5em",
+                    }
+                  }
+                >
+                  <span
+                    className="ant-tag"
+                    style={
+                      Object {
+                        "backgroundColor": undefined,
+                      }
+                    }
+                  >
+                    TestSink
+                  </span>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Features
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <span
+                    className="ant-tag"
+                    style={
+                      Object {
+                        "backgroundColor": undefined,
+                      }
+                    }
+                  >
+                    always-via:test
+                  </span>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br />
+      <div
+        style={
+          Object {
+            "textAlign": "center",
+          }
+        }
+      >
+        <button
+          className="ant-btn ant-btn-dashed"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+        >
+          <span>
+            Load More...
+          </span>
+        </button>
+      </div>
+    </section>
+    <aside
+      className="ant-layout-sider ant-layout-sider-dark"
+      style={
+        Object {
+          "flex": "0 0 300px",
+          "maxWidth": "300px",
+          "minWidth": "300px",
+          "width": "300px",
+        }
+      }
+    >
+      <div
+        className="ant-layout-sider-children"
+      >
+        <div
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <button
+            className="ant-btn"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="filter"
+              className="anticon anticon-filter"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="filter"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M880.1 154H143.9c-24.5 0-39.8 26.7-27.5 48L349 597.4V838c0 17.7 14.2 32 31.8 32h262.4c17.6 0 31.8-14.3 31.8-32V597.4L907.7 202c12.2-21.3-3.1-48-27.6-48zM603.4 798H420.6V642h182.9v156zm9.6-236.6l-9.5 16.6h-183l-9.5-16.6L212.7 226h598.6L613 561.4z"
+                />
+              </svg>
+            </span>
+            <span>
+              Filter...
+            </span>
+          </button>
+        </div>
+        <ul
+          className="ant-menu ant-menu-light ant-menu-root ant-menu-inline"
+          onMouseEnter={[Function]}
+          onTransitionEnd={[Function]}
+          role="menu"
+          style={
+            Object {
+              "borderRight": 0,
+            }
+          }
+        >
+          <div
+            className="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "padding": "12px 12px 0 12px",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className="ant-select-selector"
+              onMouseDown={[Function]}
+            >
+              <span
+                className="ant-select-selection-search"
+              >
+                <span
+                  className="ant-input-affix-wrapper ant-input-search ant-select-selection-search-input"
+                  onMouseUp={[Function]}
+                  style={
+                    Object {
+                      "opacity": null,
+                    }
+                  }
+                >
+                  <input
+                    aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                    aria-autocomplete="list"
+                    aria-controls="rc_select_TEST_OR_SSR_list"
+                    aria-haspopup="listbox"
+                    aria-owns="rc_select_TEST_OR_SSR_list"
+                    autoComplete="off"
+                    className="ant-input"
+                    id="rc_select_TEST_OR_SSR"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onCompositionEnd={[Function]}
+                    onCompositionStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onPaste={[Function]}
+                    placeholder="saved filter"
+                    readOnly={false}
+                    role="combobox"
+                    style={null}
+                    type="search"
+                    unselectable={null}
+                    value=""
+                  />
+                  <span
+                    className="ant-input-suffix"
+                  >
+                    <span
+                      aria-label="search"
+                      className="anticon anticon-search ant-input-search-icon"
+                      onClick={[Function]}
+                      role="img"
+                      tabIndex={-1}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className=""
+                        data-icon="search"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+          <li
+            className="ant-menu-submenu ant-menu-submenu-inline"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="menuitem"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup="true"
+              className="ant-menu-submenu-title"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              style={
+                Object {
+                  "paddingLeft": 24,
+                }
+              }
+            >
+              <span
+                aria-label="setting"
+                className="anticon anticon-setting"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="setting"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Filter options
+              </span>
+              <i
+                className="ant-menu-submenu-arrow"
+              />
+            </div>
+            <div />
+          </li>
+          <li
+            className="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open ant-menu-submenu-disabled"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="menuitem"
+          >
+            <div
+              aria-expanded={true}
+              aria-haspopup="true"
+              aria-owns="recents$Menu"
+              className="ant-menu-submenu-title"
+              role="button"
+              style={
+                Object {
+                  "paddingLeft": 24,
+                }
+              }
+            >
+              <span
+                aria-label="field-time"
+                className="anticon anticon-field-time"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="field-time"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <defs>
+                    <style />
+                  </defs>
+                  <path
+                    d="M945 412H689c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h256c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM811 548H689c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h122c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM477.3 322.5H434c-6.2 0-11.2 5-11.2 11.2v248c0 3.6 1.7 6.9 4.6 9l148.9 108.6c5 3.6 12 2.6 15.6-2.4l25.7-35.1v-.1c3.6-5 2.5-12-2.5-15.6l-126.7-91.6V333.7c.1-6.2-5-11.2-11.1-11.2z"
+                  />
+                  <path
+                    d="M804.8 673.9H747c-5.6 0-10.9 2.9-13.9 7.7a321 321 0 01-44.5 55.7 317.17 317.17 0 01-101.3 68.3c-39.3 16.6-81 25-124 25-43.1 0-84.8-8.4-124-25-37.9-16-72-39-101.3-68.3s-52.3-63.4-68.3-101.3c-16.6-39.2-25-80.9-25-124 0-43.1 8.4-84.7 25-124 16-37.9 39-72 68.3-101.3 29.3-29.3 63.4-52.3 101.3-68.3 39.2-16.6 81-25 124-25 43.1 0 84.8 8.4 124 25 37.9 16 72 39 101.3 68.3a321 321 0 0144.5 55.7c3 4.8 8.3 7.7 13.9 7.7h57.8c6.9 0 11.3-7.2 8.2-13.3-65.2-129.7-197.4-214-345-215.7-216.1-2.7-395.6 174.2-396 390.1C71.6 727.5 246.9 903 463.2 903c149.5 0 283.9-84.6 349.8-215.8a9.18 9.18 0 00-8.2-13.3z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Recent filters
+              </span>
+              <i
+                className="ant-menu-submenu-arrow"
+              />
+            </div>
+            <ul
+              className="ant-menu ant-menu-sub ant-menu-inline"
+              id="recents$Menu"
+              role="menu"
+              style={Object {}}
+            />
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </section>,
+]
+`;

--- a/sapp/ui/frontend/src/__snapshots__/Runs.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Runs.test.js.snap
@@ -1,0 +1,313 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders runs 1`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Runs
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <div
+    className="ant-row"
+    style={
+      Object {
+        "marginLeft": -8,
+        "marginRight": -8,
+      }
+    }
+  >
+    <div
+      className="ant-col ant-col-8"
+      style={
+        Object {
+          "paddingLeft": 8,
+          "paddingRight": 8,
+        }
+      }
+    >
+      <div
+        className="ant-card ant-card-bordered"
+      >
+        <div
+          className="ant-card-body"
+          style={Object {}}
+        >
+          <div
+            style={
+              Object {
+                "height": "12em",
+                "paddingTop": "5em",
+                "textAlign": "center",
+              }
+            }
+          >
+            <span
+              className="ant-typography ant-typography-secondary"
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                }
+              }
+            >
+              <span
+                aria-label="loading"
+                className="anticon anticon-loading"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="anticon-spin"
+                  data-icon="loading"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                  />
+                </svg>
+              </span>
+              <br />
+              Loading runs...
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Renders runs 2`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Runs
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <div
+    className="ant-row"
+    style={
+      Object {
+        "marginLeft": -8,
+        "marginRight": -8,
+      }
+    }
+  >
+    <div
+      className="ant-col ant-col-8"
+      style={
+        Object {
+          "paddingLeft": 8,
+          "paddingRight": 8,
+        }
+      }
+    >
+      <div
+        className="ant-card ant-card-bordered ant-card-small"
+      >
+        <div
+          className="ant-card-head"
+          style={Object {}}
+        >
+          <div
+            className="ant-card-head-wrapper"
+          >
+            <div
+              className="ant-card-head-title"
+            >
+              <span
+                aria-label="sync"
+                className="anticon anticon-sync"
+                role="img"
+                style={
+                  Object {
+                    "marginRight": ".5em",
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="sync"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
+                  />
+                </svg>
+              </span>
+              Run 
+              1
+            </div>
+            <div
+              className="ant-card-extra"
+            >
+              <a
+                className="ant-typography"
+                href="/run/1"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Issues
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ant-card-body"
+          style={Object {}}
+        >
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-4"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Date
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-20"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <code>
+                    Dummy date
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <ul
+          className="ant-card-actions"
+        >
+          <li
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          >
+            <span>
+              <span
+                aria-label="delete"
+                className="anticon anticon-delete"
+                onClick={[Function]}
+                role="img"
+                tabIndex={-1}
+              >
+                <svg
+                  aria-hidden="true"
+                  className=""
+                  data-icon="delete"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </li>
+        </ul>
+      </div>
+      <br />
+    </div>
+  </div>,
+]
+`;


### PR DESCRIPTION

Adds Jest testing platform and basic tests to make sure Issues, Runs,
and Filters are rendering. Uses Apollo MockedProvider to produce mocked
responses so that tests can run without the flask backend.

Adds two tests for issues and runs: to check whether issues along with
filters or runs are being rendered when provided with a mock response
(first loading is checked, and then rendering).

Adds 4 snapshots - issues rendered, issues loading, runs rendered, runs
loading which will be checked against in the future to make sure we get
the intended results.

Adds a Github Action as well to enable these "ui-tests".

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/pyre-check/issues/48