### PR TITLE
Adds minimum width to status dropdown

### DIFF
--- a/sapp/ui/frontend/src/Issue.js
+++ b/sapp/ui/frontend/src/Issue.js
@@ -187,7 +187,8 @@ const StatusSelect = (
     <Select
       size='small'
       defaultValue={props.status}
-      onChange={updateStatusFunc}>
+      onChange={updateStatusFunc}
+      style={{minWidth: '130px'}}>
       {allStatuses}
     </Select>
   );


### PR DESCRIPTION
Tiny nit adding minimum width to status dropdown so that the options
would never be displayed in a truncated fashion when the option with the
least length is selected.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes part of https://github.com/MLH-Fellowship/pyre-check/issues/49