### PR TITLE
Add syntax highlighting support for more languages

### DIFF
--- a/sapp/ui/frontend/src/Source.js
+++ b/sapp/ui/frontend/src/Source.js
@@ -19,6 +19,7 @@ import './Source.css';
 require('codemirror/lib/codemirror.css');
 require('codemirror/addon/fold/foldcode.js');
 require('codemirror/mode/python/python.js');
+require('codemirror/mode/clike/clike.js');
 
 const {Text} = Typography;
 
@@ -31,6 +32,18 @@ type Range = $ReadOnly<{
   from: Location,
   to: Location,
 }>;
+
+const modes = {
+  py: "text/x-python",
+  pyx: "text/x-cython",
+  java: "text/x-java",
+  kt: "text/x-kotlin",
+  c: "text/x-csrc",
+  cpp: "text/x-c++src",
+  cs: "text/x-csharp",
+  m: "text/x-objectivec",
+  scala: "text/x-scala",
+}
 
 function adjustRange(range: Range, lines: $ReadOnlyArray<string>): Range {
   // TODO(T78595608): workaround for inaccurate Pysa locations with leading and
@@ -183,6 +196,8 @@ function Source(
     const range = parseRanges(props.location, lines)[0];
     line = range.from.line;
     const titos = parseRanges(props.titos, lines);
+    const fileExtension = props.path.split('.').pop();
+    const mode = modes[fileExtension] || modes["py"];
 
     const ranges = [...titos, range].sort(
       (left, right) => left.from.line - right.from.line,
@@ -197,7 +212,7 @@ function Source(
     content = (
       <CodeMirror
         value={source}
-        options={{lineNumbers: true, readOnly: 'true'}}
+        options={{lineNumbers: true, readOnly: 'true', mode: mode}}
         editorDidMount={nativeEditor => {
           editor = nativeEditor;
 


### PR DESCRIPTION
Previously syntax highlighting of code in traces section was confined to
just python code using CodeMirror. Since, SAPP is not just confined to
analyze results of python based static analyzers, and it is capable of
supporting other static analyzers, adds support for many more languages
including Java, Kotlin, C++, C, C#, etc. while retaining support for
python.

CodeMirror requires "code-mode" js files to be imported for it to
support that language via the mode parameter. Support for C and other
languages in addition to Java was added since they are present in the
c-like.js mode file needed for Java.

Decision to decide which language mode to use is based on file
extension with the help of a defined javascript object. Fallback if a
unsupported extension is encountered is python.

Test Plan:
- Download the [zip of a SAPP db](https://github.com/MLH-Fellowship/sapp/files/7231200/sapp.db.zip) containing the MT run to help you reproduce the issue and the [source code of what MT was run on](https://github.com/MLH-Fellowship/sapp/files/7231267/repo.zip)
- Extract both zip files and run the following command to [get started](https://github.com/facebook/sapp#development-environment-setup)  looking into this in SAPP:
```
python3 -m sapp.cli server --source-directory repo/ --debug
```
- After the frontend has also started in debug mode (`npm run-script start`), go to `localhost:3000`, click on any issue
- See proper syntax highlighting in place.

Fixes: https://github.com/MLH-Fellowship/sapp/issues/5
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>