### PR TITLE
Makes Dalvik Code in source and sinks readable

### DIFF
--- a/sapp/ui/frontend/src/HumanReadable.js
+++ b/sapp/ui/frontend/src/HumanReadable.js
@@ -76,7 +76,7 @@ function makeDalvikClassHumanReadable(input: string): string {
   return split[split.length - 1].slice(0, -1);
 }
 
-function makeDalvikHumanReadable(input: string): string {
+export function makeDalvikHumanReadable(input: string): string {
   const match = input.match(/(.*);\.(.*):\((.*)\)(.*)/);
   if (match == null) {
     return input;

--- a/sapp/ui/frontend/src/Issue.js
+++ b/sapp/ui/frontend/src/Issue.js
@@ -31,7 +31,7 @@ import {
 } from '@ant-design/icons';
 import Source from './Source.js';
 import {Documentation} from './Documentation.js';
-import {HumanReadable} from './HumanReadable';
+import {HumanReadable, makeDalvikHumanReadable} from './HumanReadable';
 
 const {Option} = Select;
 const {Text, Link} = Typography;
@@ -40,6 +40,7 @@ function ShowMore(
   props: $ReadOnly<{|
     items: $ReadOnlyArray<string>,
     maximumElementsToShow: number,
+    displayToolTip?: boolean,
   |}>,
 ): React$Node {
   const [showMore, setShowMore] = useState(false);
@@ -49,7 +50,17 @@ function ShowMore(
     return (
       <>
         {items.map(feature => (
-          <Tag>{feature}</Tag>
+          props.displayToolTip?
+            <Tooltip title={feature}>
+              <Tag>
+                {
+                  feature.includes(";")?
+                    makeDalvikHumanReadable(feature) : feature
+                }
+              </Tag>
+            </Tooltip>
+          :
+            <Tag>{feature}</Tag>
         ))}
       </>
     );
@@ -61,8 +72,18 @@ function ShowMore(
     const moreToShow = items.length - truncatedItems.length;
     return (
       <>
-        {truncatedItems.map(item => (
-          <Tag>{item}</Tag>
+        {truncatedItems.map(feature => (
+          props.displayToolTip?
+            <Tooltip title={feature}>
+              <Tag>
+                {
+                  feature.includes(";")?
+                    makeDalvikHumanReadable(feature) : feature
+                }
+              </Tag>
+            </Tooltip>
+          :
+            <Tag>{feature}</Tag>
         ))}
         <Tag
           onClick={() => setShowMore(!showMore)}
@@ -113,11 +134,9 @@ function Leaves(
         <Text underline>minimum distance {props.distance}.</Text>
       </DelayedTooltip>
       <br />
-      <DelayedTooltip placement="right" content={Documentation.issues.name}>
-        <div style={{marginTop: '.5em'}}>
-          <ShowMore items={props.names} maximumElementsToShow={5} />
-        </div>
-      </DelayedTooltip>
+      <div style={{marginTop: '.5em'}}>
+        <ShowMore items={props.names} maximumElementsToShow={5} displayToolTip={true}/>
+      </div>
     </>
   );
 }

--- a/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Issues.test.js.snap
@@ -1135,8 +1135,6 @@ Array [
                 </span>
                 <br />
                 <div
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
                   style={
                     Object {
                       "marginTop": ".5em",
@@ -1145,6 +1143,8 @@ Array [
                 >
                   <span
                     className="ant-tag"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     style={
                       Object {
                         "backgroundColor": undefined,
@@ -1246,8 +1246,6 @@ Array [
                 </span>
                 <br />
                 <div
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
                   style={
                     Object {
                       "marginTop": ".5em",
@@ -1256,6 +1254,8 @@ Array [
                 >
                   <span
                     className="ant-tag"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     style={
                       Object {
                         "backgroundColor": undefined,


### PR DESCRIPTION
Sometimes, sink names and source names in issues can take up the form of
Dalvik Codes which are hard to read. Adds code to make use of the
existing Davlik to Human Readable converter used for readables apply to
sink and source names.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/sapp/issues/6

Test plan:
- Download the [zip of a SAPP db](https://github.com/MLH-Fellowship/sapp/files/7231200/sapp.db.zip) containing the MT run to help you reproduce the issue and the [source code of what MT was run on](https://github.com/MLH-Fellowship/sapp/files/7231267/repo.zip)
- Extract both zip files and run the following command to [get started](https://github.com/facebook/sapp#development-environment-setup)  looking into this in SAPP:
```
python3 -m sapp.cli server --source-directory repo/ --debug
```
- After the frontend has also started in debug mode (`npm run-script start`), go to `localhost:3000`
- See that sink and source names don't use Dalvik code anymore.