### PR TITLE
makes Web UI display the last character of callable class name for MT issues

### DIFF
--- a/sapp/ui/frontend/src/HumanReadable.js
+++ b/sapp/ui/frontend/src/HumanReadable.js
@@ -73,7 +73,8 @@ function makeDalvikClassHumanReadable(input: string): string {
   }
 
   const split = input.split('/');
-  return split[split.length - 1].slice(0, -1);
+  const last = split[split.length - 1];
+  return last[last.length-1] === ';' ? last.slice(0, -1) : last;
 }
 
 function makeDalvikHumanReadable(input: string): string {

--- a/sapp/ui/frontend/src/HumanReadable.js
+++ b/sapp/ui/frontend/src/HumanReadable.js
@@ -65,7 +65,7 @@ function makeDalvikParametersHumanReadable(input: string): Array<string> {
   }
 }
 
-function makeDalvikClassHumanReadable(input: string): string {
+export function makeDalvikClassHumanReadable(input: string): string {
   switch (input) {
     case 'I': return 'int';
     case 'V': return 'void';

--- a/sapp/ui/frontend/src/HumanReadable.test.js
+++ b/sapp/ui/frontend/src/HumanReadable.test.js
@@ -1,0 +1,16 @@
+import {makeDalvikClassHumanReadable} from './HumanReadable'
+
+
+describe('makeDalvikClassHumanReadable', ()=>{
+    test('returns human readable return_type', ()=>{
+        expect(makeDalvikClassHumanReadable("V")).toBe("void");
+        expect(makeDalvikClassHumanReadable("I")).toBe("int");
+        expect(makeDalvikClassHumanReadable("Z")).toBe("boolean");
+    })
+
+    test('returns human readable class name', ()=>{
+        expect(makeDalvikClassHumanReadable("Lcom/example/myapplication/MainActivity")).toBe("MainActivity");
+        expect(makeDalvikClassHumanReadable("Landroid/os/Bundle;")).toBe("Bundle");
+    })
+
+})


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

For MT issues, the last character of the callable field is missing
for example, **_y_** is missing in **_MainActivit_** as shown in the image below
This also reflects in the trace frame for the issue

### Before this change
![callable in issue](https://user-images.githubusercontent.com/14011954/134807318-8c231b2f-4ff6-4d93-ac50-62f5b8e1c8e3.png)
![callable in trace](https://user-images.githubusercontent.com/14011954/134806991-5994f3bf-dcaf-43b5-bd7b-61f764908c4f.png)

## Test Plan
* Here's a [zip of a SAPP db](https://github.com/MLH-Fellowship/sapp/files/7231200/sapp.db.zip) containing the MT run to help you reproduce the issue, extract it and run the following command to get started looking into this in SAPP:

* Run `python3 -m sapp.cli --database-name sapp.db --debug`

* After the frontend has also started (npm run-script start), go to localhost:3000 to view the changes

### After this change
Notice that the last character of the callable is no longer missing
![fixed callable in issue](https://user-images.githubusercontent.com/57163971/136020246-0731b7c4-203e-4405-b9e2-1b90b9040060.png)
![fixed callable in trace](https://user-images.githubusercontent.com/57163971/136020253-7a1265b0-f2c3-4f3f-ba27-85d303234073.png)

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
Relevant issue : [MLH-Fellowship/sapp #3](https://github.com/MLH-Fellowship/sapp/issues/3)
