### PR TITLE
Adds similar issues to sapp

### DIFF
--- a/sapp/ui/frontend/src/Issue.js
+++ b/sapp/ui/frontend/src/Issue.js
@@ -141,6 +141,7 @@ export type IssueDescription = {
   first_seen: string,
   is_new_issue: boolean,
   warning_message: string,
+  similar_issues: $ReadOnlyArray<$ReadOnlyArray<string>>
 };
 
 export const statusMap = {
@@ -220,6 +221,26 @@ export function Issue(
       </Col>
     );
   };
+  let similar_issues = null;
+
+  if (props.issue.similar_issues !== undefined) {
+    const issues = props.issue.similar_issues.map(
+      similar_issue => `Issue ${similar_issue['issue_id']} (${similar_issue['score']})`
+    );
+    similar_issues = (
+      <Row gutter={gutter}>
+        <Label>Similar Issues</Label>
+        <Item>
+          <div>
+            <ShowMore
+              items={issues.length? issues: ["None"]}
+              maximumElementsToShow={5}
+            />
+          </div>
+        </Item>
+      </Row>
+    );
+  }
 
   return (
     <Card
@@ -336,6 +357,7 @@ export function Issue(
           </DelayedTooltip>
         </Item>
       </Row>
+      {similar_issues}
     </Card>
   );
 }

--- a/sapp/ui/frontend/src/Traces.js
+++ b/sapp/ui/frontend/src/Traces.js
@@ -370,6 +370,10 @@ export const IssueQuery = gql`
           min_trace_length_to_sinks
           first_seen
           status
+          similar_issues {
+            issue_id
+            score
+          }
         }
       }
     }

--- a/sapp/ui/frontend/src/Traces.test.js
+++ b/sapp/ui/frontend/src/Traces.test.js
@@ -60,6 +60,7 @@ test("Renders traces", async () => {
         min_trace_length_to_sources: 0,
         min_trace_length_to_sinks: 0,
         first_seen: "2001-02-24 16:31:12.2402201",
+        similar_issues: [{"issue_id": "2", "score": "0.75"}],
       },
     }],
     pageInfo: {

--- a/sapp/ui/frontend/src/__snapshots__/Traces.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Traces.test.js.snap
@@ -1220,6 +1220,74 @@ Array [
           </span>
         </div>
       </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Similar Issues
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <div>
+              <span
+                className="ant-tag"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                Issue 2 (0.75)
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
     </div>
   </div>,
   <br />,

--- a/sapp/ui/schema.py
+++ b/sapp/ui/schema.py
@@ -218,6 +218,7 @@ class Query(graphene.ObjectType):
             .where_issue_instance_id_is(issue_instance_id)
             .get()
         )
+
         return issues
 
     def resolve_initial_trace_frames(

--- a/sapp/ui/tests/interactive_test.py
+++ b/sapp/ui/tests/interactive_test.py
@@ -1802,6 +1802,8 @@ class InteractiveTest(TestCase):
             sink_kinds=["sink1", "sink2"],
             status=IssueStatus.UNCATEGORIZED,
             first_seen="2001-02-24 16:31:27.1234",
+            similar_issues={(2, "0.24")},
+            run_id=1,
         )
         sources = []
         sinks = ["sink1", "sink2"]
@@ -1839,6 +1841,8 @@ class InteractiveTest(TestCase):
             sink_kinds=["sink1"],
             status=IssueStatus.UNCATEGORIZED,
             first_seen="2001-02-24 16:31:27.1234",
+            similar_issues={(2, "0.24")},
+            run_id=1,
         )
         sources = []
         sinks = ["sink1"]
@@ -1875,6 +1879,8 @@ class InteractiveTest(TestCase):
             sink_kinds=["sink1", "sink2"],
             status=IssueStatus.UNCATEGORIZED,
             first_seen="2001-02-24 16:31:27.1234",
+            similar_issues={(2, "0.24")},
+            run_id=1,
         )
         sources = []
         sinks = ["sink1", "sink2"]
@@ -1902,6 +1908,8 @@ class InteractiveTest(TestCase):
             sink_kinds=["sink1", "sink2"],
             status=IssueStatus.UNCATEGORIZED,
             first_seen="2001-02-24 16:31:27.1234",
+            similar_issues={(2, "0.24")},
+            run_id=1,
         )
         sources = []
         sinks = ["sink1", "sink2"]


### PR DESCRIPTION
Adds similar issues option to sapp to display similar issues associated with each issue.
Adds code in backend to compute similar issues, frontend to display them, and frontend
tests and jest snapshots to honour the new value.

Test plan:
- make sure there's a sapp.db with results injected from pysa or Mariana Trench
- run sapp in debug or production mode:
`python3 -m sapp.cli server --debug` or without `--debug`
- if in production mode, compile the frontend:
```
cd sapp/ui/frontend
npm install
npm run-script build
```
- if in debug mode, start the frontend in development mode:
```
cd sapp/ui/frontend
npm run-script start
```
- goto http://localhost:5000 if in production mode or http://localhost:3000 if in debug mode.
- see similar issues

Fixes: https://github.com/MLH-Fellowship/sapp/issues/9
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>