### PR TITLE
Bug fix: Display status and first seen in traces

### DIFF
--- a/sapp/ui/frontend/src/Traces.js
+++ b/sapp/ui/frontend/src/Traces.js
@@ -370,6 +370,8 @@ function Trace(props: $ReadOnly<{|match: any|}>): React$Node {
             features
             min_trace_length_to_sources
             min_trace_length_to_sinks
+            first_seen
+            status
           }
         }
       }


### PR DESCRIPTION
Status and first seen wasn't appearing in traces page because they
weren't being fetched from the graphql query. Updates the query to
include both those fields.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

Test Plan

- make sure there's a sapp.db with results injected from pysa or Mariana Trench
- run sapp in debug or production mode:
`python3 -m sapp.cli server --debug` or without `--debug`
- if in production mode, compile the frontend:
```
cd sapp/ui/frontend
npm install
npm run-script build
```
- if in debug mode, start the frontend in development mode:
```
cd sapp/ui/frontend
npm run-script start
```
- goto http://localhost:5000 if in production mode or http://localhost:3000 if in debug mode.
- click on an issue and see status and first seen appear

Before:
<img width="1440" alt="Screenshot 2021-10-13 at 9 10 59 PM" src="https://user-images.githubusercontent.com/8947010/137168473-75d981b1-48df-4f1a-94c0-3b0c1231d85e.png">

After:
<img width="1440" alt="Screenshot 2021-10-13 at 9 13 24 PM" src="https://user-images.githubusercontent.com/8947010/137168514-652b70f7-b837-4ea2-bef3-8fc7085c1d0f.png">

