### PR TITLE
Adds jest tests for Traces.js

### DIFF
--- a/sapp/ui/frontend/src/Source.js
+++ b/sapp/ui/frontend/src/Source.js
@@ -151,23 +151,24 @@ function computeLayout(
   return {totalLines, folds};
 }
 
+export const SourceQuery = gql`
+  query Issue($path: String) {
+    file(path: $path) {
+      edges {
+        node {
+          contents
+          editor_link
+        }
+      }
+    }
+  }
+`;
+
 function Source(
   props: $ReadOnly<{|path: string, location: string, titos?: string|}>,
 ): React$Node {
   var line = null;
 
-  const SourceQuery = gql`
-    query Issue($path: String) {
-      file(path: $path) {
-        edges {
-          node {
-            contents
-            editor_link
-          }
-        }
-      }
-    }
-  `;
   const {loading, error, data} = useQuery(SourceQuery, {
     variables: {path: props.path},
   });

--- a/sapp/ui/frontend/src/Traces.js
+++ b/sapp/ui/frontend/src/Traces.js
@@ -249,6 +249,25 @@ function LoadFrame(
   );
 }
 
+export const InitialTraceFramesQuery = gql`
+  query InitialTraceFrame($issue_instance_id: Int!, $kind: String!) {
+    initial_trace_frames(issue_instance_id: $issue_instance_id, kind: $kind) {
+      edges {
+        node {
+          frame_id
+          callee
+          callee_id
+          filename
+          callee_location
+          trace_length
+          is_leaf
+        }
+      }
+    }
+  }
+`;
+
+
 function Expansion(
   props: $ReadOnly<{|
     issue_instance_id: number,
@@ -256,23 +275,6 @@ function Expansion(
     kind: Kind,
   |}>,
 ): React$Node {
-  const InitialTraceFramesQuery = gql`
-    query InitialTraceFrame($issue_instance_id: Int!, $kind: String!) {
-      initial_trace_frames(issue_instance_id: $issue_instance_id, kind: $kind) {
-        edges {
-          node {
-            frame_id
-            callee
-            callee_id
-            filename
-            callee_location
-            trace_length
-            is_leaf
-          }
-        }
-      }
-    }
-  `;
   const {loading, error, data} = useQuery(InitialTraceFramesQuery, {
     variables: {issue_instance_id: props.issue_instance_id, kind: props.kind},
   });
@@ -347,36 +349,37 @@ function Expansion(
   );
 }
 
-function Trace(props: $ReadOnly<{|match: any|}>): React$Node {
-  const run_id = props.match.params.run_id;
-  const issue_instance_id = props.match.params.issue_instance_id;
-
-  const IssueQuery = gql`
-    query Issue($run_id: Int!, $issue_instance_id: Int!) {
-      issues(run_id: $run_id, issue_instance_id: $issue_instance_id) {
-        edges {
-          node {
-            issue_id
-            issue_instance_id
-            code
-            message
-            callable
-            filename
-            location
-            sources
-            source_names
-            sinks
-            sink_names
-            features
-            min_trace_length_to_sources
-            min_trace_length_to_sinks
-            first_seen
-            status
-          }
+export const IssueQuery = gql`
+  query Issue($run_id: Int!, $issue_instance_id: Int!) {
+    issues(run_id: $run_id, issue_instance_id: $issue_instance_id) {
+      edges {
+        node {
+          issue_id
+          issue_instance_id
+          code
+          message
+          callable
+          filename
+          location
+          sources
+          source_names
+          sinks
+          sink_names
+          features
+          min_trace_length_to_sources
+          min_trace_length_to_sinks
+          first_seen
+          status
         }
       }
     }
-  `;
+  }
+`;
+
+export function Trace(props: $ReadOnly<{|match: any|}>): React$Node {
+  const run_id = props.match.params.run_id;
+  const issue_instance_id = props.match.params.issue_instance_id;
+
   const {loading, error, data} = useQuery(IssueQuery, {
     variables: {run_id, issue_instance_id},
   });

--- a/sapp/ui/frontend/src/Traces.test.js
+++ b/sapp/ui/frontend/src/Traces.test.js
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { MockedProvider } from '@apollo/client/testing';
+import { Trace, IssueQuery, InitialTraceFramesQuery } from './Traces'
+import { Issue } from './Issue';
+import { SourceQuery } from './Source';
+
+const {act} = TestRenderer;
+
+test("Renders traces", async () => {
+  // Mock window.matchMedia
+  window.matchMedia = window.matchMedia || function() {
+    return {
+      matches: false,
+      addListener: function() {},
+      removeListener: function() {}
+    };
+  };
+  // Mock document.body.createTextRange
+  document.body.createTextRange = document.body.createTextRange || function() {
+    return {
+      setStart: () => {},
+      setEnd: () => {},
+      getBoundingClientRect: () => {return {length: 0}},
+      getClientRects: () => {return {length: 0}},
+      commonAncestorContainer: {
+        nodeName: 'BODY',
+        ownerDocument: document,
+      },
+    }
+  };
+
+  const mockIssue = {
+    edges: [{
+      node: {
+        issue_id: "1",
+        issue_instance_id: "11",
+        code: 6065,
+        message: "This is a test issue",
+        callable: "run.test",
+        filename: "tests.js",
+        location: "1|0|0",
+        sources: ["TestSource"],
+        source_names: ["TestSource"],
+        sinks: ["TestSink"],
+        sink_names: ["TestSink"],
+        status: "Uncategorized",
+        features: ["always-via:test"],
+        is_new_issue: false,
+        min_trace_length_to_sources: 0,
+        min_trace_length_to_sinks: 0,
+        first_seen: "2001-02-24 16:31:12.2402201",
+      },
+    }],
+    pageInfo: {
+      endCursor: "TestCursor",
+    },
+  };
+
+  const mockPreTrace = {
+    edges: [{
+      node: {
+        frame_id: "116",
+        callee: "TestCallee",
+        callee_id: "19",
+        filename: "test.js",
+        callee_location: "1|0|0",
+        trace_length: 0,
+        is_leaf: true,
+      },
+    }]
+  };
+
+  const mockPostTrace = {
+    edges: [{
+      node: {
+        frame_id: "115",
+        callee: "TestCallee",
+        callee_id: "4",
+        filename: "test.js",
+        callee_location: "1|0|0",
+        trace_length: 0,
+        is_leaf: true,
+      },
+    }]
+  };
+
+  const mockSource = {
+    edges: [{
+      node: {
+        contents: "test\n\n\ntest",
+        editor_link: null,
+      },
+    }]
+  };
+
+  const mocks = [{
+    request: {
+      query: IssueQuery,
+      variables: {
+        run_id: "0",
+        issue_instance_id: 11,
+      },
+    },
+    result: {
+      data: {
+        issues: mockIssue,
+      },
+    },
+  },
+  {
+    request: {
+      query: InitialTraceFramesQuery,
+      variables: {
+        issue_instance_id: 11,
+        kind: "precondition"
+      },
+    },
+    result: {
+      data: {
+        initial_trace_frames: mockPreTrace,
+      },
+    },
+  },
+  {
+    request: {
+      query: InitialTraceFramesQuery,
+      variables: {
+        issue_instance_id: 11,
+        kind: "postcondition"
+      },
+    },
+    result: {
+      data: {
+        initial_trace_frames: mockPostTrace,
+      },
+    },
+  },
+  {
+    request: {
+      query: SourceQuery,
+      variables: {
+        path: "test.js"
+      },
+    },
+    result: {
+      data: {
+        file: mockSource,
+      },
+    },
+  }];
+
+  const match = {
+    params: {
+      run_id: "0",
+      issue_instance_id: 11,
+    },
+  };
+
+  const component = TestRenderer.create(
+    <MockedProvider mocks={mocks}>
+      <Trace match={match}/>
+    </MockedProvider>
+  );
+
+  // Mocked provider hasn't populated the results yet. Use it to test loading
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  /**
+   * Await a zero-millisecond timeout. This delays the checks until the next
+   * "tick" of the event loop, which gives MockedProvider an opportunity to
+   * populate the mocked result. Await three ticks because there are three
+   * `useQuery` functions called in Traces.js. First tick renders the issue,
+   * second renders the pre-condition trace, the third renders the
+   * post-condition, and the last the source.
+   */
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  tree = component.toJSON();
+  const instance = component.root;
+  expect(instance.findByType(Issue).props.issue.callable).toBe('run.test');
+  expect(tree).toMatchSnapshot();
+});

--- a/sapp/ui/frontend/src/__snapshots__/Traces.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Traces.test.js.snap
@@ -1,0 +1,1840 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders traces 1`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/runs"
+      >
+        Runs
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/run/0"
+      >
+        Run 
+        0
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Issue 
+        
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <div
+        className="ant-skeleton ant-skeleton-active"
+      >
+        <div
+          className="ant-skeleton-content"
+        >
+          <h3
+            className="ant-skeleton-title"
+            style={
+              Object {
+                "width": "38%",
+              }
+            }
+          />
+          <ul
+            className="ant-skeleton-paragraph"
+          >
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": "61%",
+                }
+              }
+            />
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <div
+        className="ant-skeleton ant-skeleton-active"
+      >
+        <div
+          className="ant-skeleton-content"
+        >
+          <h3
+            className="ant-skeleton-title"
+            style={
+              Object {
+                "width": "38%",
+              }
+            }
+          />
+          <ul
+            className="ant-skeleton-paragraph"
+          >
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": "61%",
+                }
+              }
+            />
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <div
+        className="ant-skeleton ant-skeleton-active"
+      >
+        <div
+          className="ant-skeleton-content"
+        >
+          <h3
+            className="ant-skeleton-title"
+            style={
+              Object {
+                "width": "38%",
+              }
+            }
+          />
+          <ul
+            className="ant-skeleton-paragraph"
+          >
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": "61%",
+                }
+              }
+            />
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <div
+        className="ant-skeleton ant-skeleton-active"
+      >
+        <div
+          className="ant-skeleton-content"
+        >
+          <h3
+            className="ant-skeleton-title"
+            style={
+              Object {
+                "width": "38%",
+              }
+            }
+          />
+          <ul
+            className="ant-skeleton-paragraph"
+          >
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            />
+            <li
+              style={
+                Object {
+                  "width": "61%",
+                }
+              }
+            />
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+]
+`;
+
+exports[`Renders traces 2`] = `
+Array [
+  <div
+    className="ant-breadcrumb"
+    style={
+      Object {
+        "margin": "16px 0",
+      }
+    }
+  >
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/runs"
+      >
+        Runs
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <a
+        className="ant-breadcrumb-link"
+        href="/run/0"
+      >
+        Run 
+        0
+      </a>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+    <span>
+      <span
+        className="ant-breadcrumb-link"
+      >
+        Issue 
+        1
+      </span>
+      <span
+        className="ant-breadcrumb-separator"
+      >
+        /
+      </span>
+    </span>
+  </div>,
+  <div
+    className="ant-card ant-card-bordered ant-card-small"
+  >
+    <div
+      className="ant-card-head"
+      style={Object {}}
+    >
+      <div
+        className="ant-card-head-wrapper"
+      >
+        <div
+          className="ant-card-head-title"
+        >
+          <span
+            aria-label="fire"
+            className="anticon anticon-fire"
+            role="img"
+            style={
+              Object {
+                "marginRight": ".5em",
+              }
+            }
+          >
+            <svg
+              aria-hidden="true"
+              className=""
+              data-icon="fire"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M834.1 469.2A347.49 347.49 0 00751.2 354l-29.1-26.7a8.09 8.09 0 00-13 3.3l-13 37.3c-8.1 23.4-23 47.3-44.1 70.8-1.4 1.5-3 1.9-4.1 2-1.1.1-2.8-.1-4.3-1.5-1.4-1.2-2.1-3-2-4.8 3.7-60.2-14.3-128.1-53.7-202C555.3 171 510 123.1 453.4 89.7l-41.3-24.3c-5.4-3.2-12.3 1-12 7.3l2.2 48c1.5 32.8-2.3 61.8-11.3 85.9-11 29.5-26.8 56.9-47 81.5a295.64 295.64 0 01-47.5 46.1 352.6 352.6 0 00-100.3 121.5A347.75 347.75 0 00160 610c0 47.2 9.3 92.9 27.7 136a349.4 349.4 0 0075.5 110.9c32.4 32 70 57.2 111.9 74.7C418.5 949.8 464.5 959 512 959s93.5-9.2 136.9-27.3A348.6 348.6 0 00760.8 857c32.4-32 57.8-69.4 75.5-110.9a344.2 344.2 0 0027.7-136c0-48.8-10-96.2-29.9-140.9zM713 808.5c-53.7 53.2-125 82.4-201 82.4s-147.3-29.2-201-82.4c-53.5-53.1-83-123.5-83-198.4 0-43.5 9.8-85.2 29.1-124 18.8-37.9 46.8-71.8 80.8-97.9a349.6 349.6 0 0058.6-56.8c25-30.5 44.6-64.5 58.2-101a240 240 0 0012.1-46.5c24.1 22.2 44.3 49 61.2 80.4 33.4 62.6 48.8 118.3 45.8 165.7a74.01 74.01 0 0024.4 59.8 73.36 73.36 0 0053.4 18.8c19.7-1 37.8-9.7 51-24.4 13.3-14.9 24.8-30.1 34.4-45.6 14 17.9 25.7 37.4 35 58.4 15.9 35.8 24 73.9 24 113.1 0 74.9-29.5 145.4-83 198.4z"
+              />
+            </svg>
+          </span>
+          Issue
+        </div>
+      </div>
+    </div>
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Code
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              className="ant-typography"
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                }
+              }
+            >
+              <code>
+                6065
+              </code>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Description
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            This is a test issue
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Status
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <div
+                className="ant-select ant-select-sm ant-select-single ant-select-show-arrow"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                style={
+                  Object {
+                    "minWidth": "130px",
+                  }
+                }
+              >
+                <div
+                  className="ant-select-selector"
+                  onMouseDown={[Function]}
+                >
+                  <span
+                    className="ant-select-selection-search"
+                  >
+                    <input
+                      aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                      aria-autocomplete="list"
+                      aria-controls="rc_select_TEST_OR_SSR_list"
+                      aria-haspopup="listbox"
+                      aria-owns="rc_select_TEST_OR_SSR_list"
+                      autoComplete="off"
+                      className="ant-select-selection-search-input"
+                      id="rc_select_TEST_OR_SSR"
+                      onChange={[Function]}
+                      onCompositionEnd={[Function]}
+                      onCompositionStart={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      onPaste={[Function]}
+                      readOnly={true}
+                      role="combobox"
+                      style={
+                        Object {
+                          "opacity": 0,
+                        }
+                      }
+                      type="search"
+                      unselectable="on"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    className="ant-select-selection-item"
+                    title="Uncategorized"
+                  >
+                    Uncategorized
+                  </span>
+                </div>
+                <span
+                  aria-hidden={true}
+                  className="ant-select-arrow"
+                  onMouseDown={[Function]}
+                  style={
+                    Object {
+                      "WebkitUserSelect": "none",
+                      "userSelect": "none",
+                    }
+                  }
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    className="anticon anticon-down ant-select-suffix"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className=""
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            First seen
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              className="ant-typography"
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                }
+              }
+            >
+              <code>
+                2001-02-24 16:31:12.2402201
+              </code>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Callable
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              className="ant-typography"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                  "wordBreak": "break-all",
+                }
+              }
+            >
+              <code>
+                run.test
+              </code>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Location
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              aria-label="code"
+              className="anticon anticon-code"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              role="img"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="code"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 728H184V184h656v656z"
+                  fill="#1890ff"
+                />
+                <path
+                  d="M184 840h656V184H184v656zm339.5-223h185c4.1 0 7.5 3.6 7.5 8v48c0 4.4-3.4 8-7.5 8h-185c-4.1 0-7.5-3.6-7.5-8v-48c0-4.4 3.4-8 7.5-8zM308 610.3c0-2.3 1.1-4.6 2.9-6.1L420.7 512l-109.8-92.2a7.63 7.63 0 01-2.9-6.1V351c0-6.8 7.9-10.5 13.1-6.1l192 160.9c3.9 3.2 3.9 9.1 0 12.3l-192 161c-5.2 4.4-13.1.7-13.1-6.1v-62.7z"
+                  fill="#e6f7ff"
+                />
+                <path
+                  d="M321.1 679.1l192-161c3.9-3.2 3.9-9.1 0-12.3l-192-160.9A7.95 7.95 0 00308 351v62.7c0 2.4 1 4.6 2.9 6.1L420.7 512l-109.8 92.2a8.1 8.1 0 00-2.9 6.1V673c0 6.8 7.9 10.5 13.1 6.1zM516 673c0 4.4 3.4 8 7.5 8h185c4.1 0 7.5-3.6 7.5-8v-48c0-4.4-3.4-8-7.5-8h-185c-4.1 0-7.5 3.6-7.5 8v48z"
+                  fill="#1890ff"
+                />
+              </svg>
+            </span>
+             
+            <span
+              className="ant-typography"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                  "wordBreak": "break-all",
+                }
+              }
+            >
+              <code>
+                tests.js
+              </code>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Sources
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <span
+                className="ant-tag ant-tag-green"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                TestSource
+              </span>
+            </span>
+             
+            at
+             
+            <span
+              className="ant-typography"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                }
+              }
+            >
+              <u>
+                minimum distance 
+                0
+                .
+              </u>
+            </span>
+            <br />
+            <div
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "marginTop": ".5em",
+                }
+              }
+            >
+              <span
+                className="ant-tag"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                TestSource
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Sinks
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <span
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <span
+                className="ant-tag ant-tag-red"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                TestSink
+              </span>
+            </span>
+             
+            at
+             
+            <span
+              className="ant-typography"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "WebkitLineClamp": null,
+                }
+              }
+            >
+              <u>
+                minimum distance 
+                0
+                .
+              </u>
+            </span>
+            <br />
+            <div
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "marginTop": ".5em",
+                }
+              }
+            >
+              <span
+                className="ant-tag"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                TestSink
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginBottom": 4,
+            "marginLeft": -4,
+            "marginRight": -4,
+            "marginTop": -4,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-4"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+              "textAlign": "right",
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            Features
+          </span>
+        </div>
+        <div
+          className="ant-col ant-col-20"
+          style={
+            Object {
+              "paddingBottom": 4,
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          <span
+            className="ant-typography ant-typography-secondary"
+            style={
+              Object {
+                "WebkitLineClamp": null,
+              }
+            }
+          >
+            <div
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <span
+                className="ant-tag"
+                style={
+                  Object {
+                    "backgroundColor": undefined,
+                  }
+                }
+              >
+                always-via:test
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <span
+        className="ant-typography"
+        style={
+          Object {
+            "WebkitLineClamp": null,
+          }
+        }
+      >
+        <span
+          aria-label="vertical-align-top"
+          className="anticon anticon-vertical-align-top"
+          role="img"
+          style={
+            Object {
+              "marginRight": ".5em",
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className=""
+            data-icon="vertical-align-top"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M859.9 168H164.1c-4.5 0-8.1 3.6-8.1 8v60c0 4.4 3.6 8 8.1 8h695.8c4.5 0 8.1-3.6 8.1-8v-60c0-4.4-3.6-8-8.1-8zM518.3 355a8 8 0 00-12.6 0l-112 141.7a7.98 7.98 0 006.3 12.9h73.9V848c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V509.7H624c6.7 0 10.4-7.7 6.3-12.9L518.3 355z"
+            />
+          </svg>
+        </span>
+        Data of 
+        type 
+        <span
+          className="ant-tag ant-tag-green"
+          style={
+            Object {
+              "backgroundColor": undefined,
+            }
+          }
+        >
+          TestSource
+        </span>
+        flowing 
+        <i>
+          up to
+        </i>
+         
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            run.test
+          </code>
+        </span>
+         
+        in 
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            tests.js
+          </code>
+        </span>
+        .
+      </span>
+      <div
+        className="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-plain"
+        role="separator"
+      >
+        <span
+          className="ant-divider-inner-text"
+        >
+          Traces
+        </span>
+      </div>
+      <div
+        class="source-menu"
+      >
+        <span
+          className="ant-tooltip-disabled-compatible-wrapper"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "cursor": "not-allowed",
+              "display": "inline-block",
+              "width": null,
+            }
+          }
+        >
+          <button
+            className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+            disabled={true}
+            onClick={[Function]}
+            style={
+              Object {
+                "pointerEvents": "none",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="edit"
+              className="anticon anticon-edit"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="edit"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+        <button
+          className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          type="button"
+        >
+          <span
+            aria-label="select"
+            className="anticon anticon-select"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              className=""
+              data-icon="select"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h360c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H184V184h656v320c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V144c0-17.7-14.3-32-32-32zM653.3 599.4l52.2-52.2a8.01 8.01 0 00-4.7-13.6l-179.4-21c-5.1-.6-9.5 3.7-8.9 8.9l21 179.4c.8 6.6 8.9 9.4 13.6 4.7l52.4-52.4 256.2 256.2c3.1 3.1 8.2 3.1 11.3 0l42.4-42.4c3.1-3.1 3.1-8.2 0-11.3L653.3 599.4z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="source"
+      >
+        <div
+          className="react-codemirror2"
+        />
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <span
+        className="ant-typography"
+        style={
+          Object {
+            "WebkitLineClamp": null,
+          }
+        }
+      >
+        <span
+          aria-label="vertical-align-middle"
+          className="anticon anticon-vertical-align-middle"
+          role="img"
+          style={
+            Object {
+              "marginRight": ".5em",
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className=""
+            data-icon="vertical-align-middle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M859.9 474H164.1c-4.5 0-8.1 3.6-8.1 8v60c0 4.4 3.6 8 8.1 8h695.8c4.5 0 8.1-3.6 8.1-8v-60c0-4.4-3.6-8-8.1-8zm-353.6-74.7c2.9 3.7 8.5 3.7 11.3 0l100.8-127.5c3.7-4.7.4-11.7-5.7-11.7H550V104c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v156h-62.8c-6 0-9.4 7-5.7 11.7l100.8 127.6zm11.4 225.4a7.14 7.14 0 00-11.3 0L405.6 752.3a7.23 7.23 0 005.7 11.7H474v156c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V764h62.8c6 0 9.4-7 5.7-11.7L517.7 624.7z"
+            />
+          </svg>
+        </span>
+        Source and sink traces meet at
+         
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            run.test
+          </code>
+        </span>
+         in 
+         
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            tests.js
+          </code>
+        </span>
+        .
+      </span>
+      <div
+        class="source-menu"
+      >
+        <span
+          className="ant-tooltip-disabled-compatible-wrapper"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "cursor": "not-allowed",
+              "display": "inline-block",
+              "width": null,
+            }
+          }
+        >
+          <button
+            className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+            disabled={
+              [Error: No more mocked responses for the query: query Issue($path: String) {
+  file(path: $path) {
+    edges {
+      node {
+        contents
+        editor_link
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+
+Expected variables: {"path":"tests.js"}
+]
+            }
+            onClick={[Function]}
+            style={
+              Object {
+                "pointerEvents": "none",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="edit"
+              className="anticon anticon-edit"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="edit"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+        <span
+          className="ant-tooltip-disabled-compatible-wrapper"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "cursor": "not-allowed",
+              "display": "inline-block",
+              "width": null,
+            }
+          }
+        >
+          <button
+            className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+            disabled={
+              [Error: No more mocked responses for the query: query Issue($path: String) {
+  file(path: $path) {
+    edges {
+      node {
+        contents
+        editor_link
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+
+Expected variables: {"path":"tests.js"}
+]
+            }
+            onClick={[Function]}
+            style={
+              Object {
+                "pointerEvents": "none",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="select"
+              className="anticon anticon-select"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="select"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h360c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H184V184h656v320c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V144c0-17.7-14.3-32-32-32zM653.3 599.4l52.2-52.2a8.01 8.01 0 00-4.7-13.6l-179.4-21c-5.1-.6-9.5 3.7-8.9 8.9l21 179.4c.8 6.6 8.9 9.4 13.6 4.7l52.4-52.4 256.2 256.2c3.1 3.1 8.2 3.1 11.3 0l42.4-42.4c3.1-3.1 3.1-8.2 0-11.3L653.3 599.4z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </div>
+      <div
+        class="source"
+      >
+        <div
+          className="ant-alert ant-alert-info ant-alert-no-icon"
+          data-show={true}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="alert"
+          style={Object {}}
+        >
+          <span
+            className="ant-alert-message"
+          >
+            No file found for tests.js
+          </span>
+          <span
+            className="ant-alert-description"
+          />
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    className="ant-card ant-card-bordered"
+  >
+    <div
+      className="ant-card-body"
+      style={Object {}}
+    >
+      <span
+        className="ant-typography"
+        style={
+          Object {
+            "WebkitLineClamp": null,
+          }
+        }
+      >
+        <span
+          aria-label="vertical-align-bottom"
+          className="anticon anticon-vertical-align-bottom"
+          role="img"
+          style={
+            Object {
+              "marginRight": ".5em",
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className=""
+            data-icon="vertical-align-bottom"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M859.9 780H164.1c-4.5 0-8.1 3.6-8.1 8v60c0 4.4 3.6 8 8.1 8h695.8c4.5 0 8.1-3.6 8.1-8v-60c0-4.4-3.6-8-8.1-8zM505.7 669a8 8 0 0012.6 0l112-141.7c4.1-5.2.4-12.9-6.3-12.9h-74.1V176c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v338.3H400c-6.7 0-10.4 7.7-6.3 12.9l112 141.8z"
+            />
+          </svg>
+        </span>
+        Data of 
+        type 
+        <span
+          className="ant-tag ant-tag-green"
+          style={
+            Object {
+              "backgroundColor": undefined,
+            }
+          }
+        >
+          TestSource
+        </span>
+        flowing 
+        <i>
+          from
+        </i>
+         
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            run.test
+          </code>
+        </span>
+         
+        into sinks of 
+        type 
+        <span
+          className="ant-tag ant-tag-red"
+          style={
+            Object {
+              "backgroundColor": undefined,
+            }
+          }
+        >
+          TestSink
+        </span>
+        in 
+        <span
+          className="ant-typography"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "WebkitLineClamp": null,
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          <code>
+            tests.js
+          </code>
+        </span>
+        .
+      </span>
+      <div
+        className="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-plain"
+        role="separator"
+      >
+        <span
+          className="ant-divider-inner-text"
+        >
+          Traces
+        </span>
+      </div>
+      <div
+        class="source-menu"
+      >
+        <span
+          className="ant-tooltip-disabled-compatible-wrapper"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "cursor": "not-allowed",
+              "display": "inline-block",
+              "width": null,
+            }
+          }
+        >
+          <button
+            className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+            disabled={true}
+            onClick={[Function]}
+            style={
+              Object {
+                "pointerEvents": "none",
+              }
+            }
+            type="button"
+          >
+            <span
+              aria-label="edit"
+              className="anticon anticon-edit"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                className=""
+                data-icon="edit"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+        <button
+          className="ant-btn ant-btn-text ant-btn-sm ant-btn-icon-only"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          type="button"
+        >
+          <span
+            aria-label="select"
+            className="anticon anticon-select"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              className=""
+              data-icon="select"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h360c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H184V184h656v320c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V144c0-17.7-14.3-32-32-32zM653.3 599.4l52.2-52.2a8.01 8.01 0 00-4.7-13.6l-179.4-21c-5.1-.6-9.5 3.7-8.9 8.9l21 179.4c.8 6.6 8.9 9.4 13.6 4.7l52.4-52.4 256.2 256.2c3.1 3.1 8.2 3.1 11.3 0l42.4-42.4c3.1-3.1 3.1-8.2 0-11.3L653.3 599.4z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="source"
+      >
+        <div
+          className="react-codemirror2"
+        />
+      </div>
+    </div>
+  </div>,
+  <br />,
+]
+`;


### PR DESCRIPTION
Adds jest tests for Traces.js file in Traces.test.js with jest
snapshots. Modifies Source and Traces file to make the components
importable from the test file.

Test Plan
- checkout the PR
- `cd sapp/ui/frontend`
- Run `npm run-script ui-tests`
- See the jest tests

Screenshots:
<img width="1440" alt="Screenshot 2021-10-14 at 3 00 07 PM" src="https://user-images.githubusercontent.com/8947010/137291149-6b89991c-34ad-4221-b9fa-3190d79e923e.png">

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>