### PR TITLE
Prevent sapp frontend from crashing

### DIFF
--- a/sapp/ui/frontend/src/Source.js
+++ b/sapp/ui/frontend/src/Source.js
@@ -198,7 +198,7 @@ function Source(
     // can break the frontend, display the error message in that scenario
     if (lines.length < props.location.split('|')[0]) {
       content = (
-        <Alert message={`${props.path} cannot be displayed because of mismatch in line numbers in source and issue.`} type="info" />
+        <Alert message={`${props.path} cannot be displayed because of mismatch in line numbers in the source code and the issue. This could be caused by inaccuracies in decompiled bytecode (if viewing Mariana Trench results) or by viewing a file which has been edited after it was processed by your static analyzer.`} type="info" />
       );
     } else {
       const range = parseRanges(props.location, lines)[0];


### PR DESCRIPTION
Prevent sapp frontend from crashing if there if a source file contains
less number of lines that expected.

Test Plan:
- run pysa/Mariana Trench parser and import the results to sapp
- make sure you have source code. Modify the source code to make the taint location invalid
- run sapp `python3 -m sapp.cli server --debug --source-directory <source-directory>`
- start the frontend, `cd sapp/ui/frontend && npm run-script start`
- goto https://localhost:3000 and click on an issue. 
- See sapp showing the new error message and not crashing.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/sapp/issues/4

