### PR TITLE
Metrics in runs

### DIFF
--- a/sapp/ui/frontend/src/Runs.js
+++ b/sapp/ui/frontend/src/Runs.js
@@ -27,14 +27,14 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
 
   const Label = (props: $ReadOnly<{children: React$Node}>): React$Node => {
     return (
-      <Col span={4} style={{textAlign: 'right'}}>
+      <Col span={8} style={{textAlign: 'right'}}>
         <Text type="secondary">{props.children}</Text>
       </Col>
     );
   };
   const Item = (props: $ReadOnly<{children: React$Node}>): React$Node => {
     return (
-      <Col span={20}>
+      <Col span={16}>
         <Text type="secondary">{props.children}</Text>
       </Col>
     );
@@ -91,6 +91,25 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
             <Text code>{props.run.date}</Text>
           </Item>
         </Row>
+        <Row gutter={gutter}>
+          <Label>Total issues</Label>
+          <Item>
+            <Text code>{props.run.num_issues || 0}</Text>
+          </Item>
+        </Row>
+        <Row gutter={gutter}>
+          <Label>Triaged issues</Label>
+          <Item>
+            <Text code>{props.run.triaged_issues || 0}</Text>
+          </Item>
+        </Row>
+        <Row gutter={gutter}>
+          <Label>Commit hash</Label>
+          <Item>
+            <Text code>{props.run.commit_hash || "None"}</Text>
+          </Item>
+        </Row>
+
       </Card>
       <br />
     </Col>
@@ -110,6 +129,9 @@ export const RunsQuery = gql`
         node {
           run_id
           date
+          commit_hash
+          num_issues
+          triaged_issues
         }
       }
     }

--- a/sapp/ui/frontend/src/Runs.test.js
+++ b/sapp/ui/frontend/src/Runs.test.js
@@ -36,6 +36,9 @@ test("Renders runs", async () => {
             node: {
               run_id: "1",
               date: "Dummy date",
+              triaged_issues: 10,
+              num_issues: 24,
+              commit_hash: "Dummy commit hash",
             },
           }],
         },

--- a/sapp/ui/frontend/src/__snapshots__/Runs.test.js.snap
+++ b/sapp/ui/frontend/src/__snapshots__/Runs.test.js.snap
@@ -212,7 +212,7 @@ Array [
             }
           >
             <div
-              className="ant-col ant-col-4"
+              className="ant-col ant-col-8"
               style={
                 Object {
                   "paddingBottom": 4,
@@ -235,7 +235,7 @@ Array [
               </span>
             </div>
             <div
-              className="ant-col ant-col-20"
+              className="ant-col ant-col-16"
               style={
                 Object {
                   "paddingBottom": 4,
@@ -263,6 +263,210 @@ Array [
                 >
                   <code>
                     Dummy date
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-8"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Total issues
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-16"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <code>
+                    24
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-8"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Triaged issues
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-16"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <code>
+                    10
+                  </code>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            className="ant-row"
+            style={
+              Object {
+                "marginBottom": 4,
+                "marginLeft": -4,
+                "marginRight": -4,
+                "marginTop": -4,
+              }
+            }
+          >
+            <div
+              className="ant-col ant-col-8"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                  "textAlign": "right",
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                Commit hash
+              </span>
+            </div>
+            <div
+              className="ant-col ant-col-16"
+              style={
+                Object {
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
+                }
+              }
+            >
+              <span
+                className="ant-typography ant-typography-secondary"
+                style={
+                  Object {
+                    "WebkitLineClamp": null,
+                  }
+                }
+              >
+                <span
+                  className="ant-typography"
+                  style={
+                    Object {
+                      "WebkitLineClamp": null,
+                    }
+                  }
+                >
+                  <code>
+                    Dummy commit hash
                   </code>
                 </span>
               </span>


### PR DESCRIPTION
Adds two more metrics to runs gql endpoint in the backend and in frontend: number of
issues in a run and number of triaged issues in a run.

Test Plan:
- checkout this branch
- run `python3 -m sapp.cli server --debug`
- run `cd sapp/ui/frontend && npm run-script start`
- goto localhost:3000/runs and see the new metrics
- goto localhost:5000/graphql and play around with the Runs endpoint.

Screenshots:
<img width="1440" alt="Screenshot 2021-11-01 at 8 56 39 PM" src="https://user-images.githubusercontent.com/8947010/139700007-e21e4347-0a18-4b16-8d8b-d8faaf9765be.png">

<img width="1440" alt="Screenshot 2021-11-01 at 9 13 54 PM" src="https://user-images.githubusercontent.com/8947010/139700080-61aa4515-0538-4612-9f9c-e95af43061d7.png">

Fixes: https://github.com/MLH-Fellowship/sapp/issues/10
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>