### PR TITLE
added `default=str` arguement to json.dumps call in filter_run

### DIFF
--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -258,7 +258,7 @@ def filter_run(
             LOG.info(total_filtered_issues_output)
         if output_format == "sapp":
             output_json = {"issues": [issue.to_json() for issue in query_results]}
-            print(json.dumps(output_json, indent=2))
+            print(json.dumps(output_json, indent=2, default=str))
         elif output_format == "sarif":
             sarif_output = SARIF(context.tool, session, query_results)
             print(sarif_output.to_json())


### PR DESCRIPTION
This PR adds  `default=str` arguement to json.dumps call in the `filter_run` function of   [filters.py](https://github.com/facebook/sapp/blob/main/sapp/ui/filters.py)

Without this arguement the function throws  a type error when called 

```python
TypeError: "Object of type datetime is not JSON serializable"
``` 

This is because the object passed into json.dumps contains a datetime element which cannot be serialized unless converted to a string