### PR TITLE
Fix line-number off by one error in MT parser

### DIFF
--- a/sapp/pipeline/mariana_trench_parser.py
+++ b/sapp/pipeline/mariana_trench_parser.py
@@ -133,6 +133,8 @@ class Position(NamedTuple):
     def from_json(position: Dict[str, Any], method: Method) -> "Position":
         path = position.get("path", UNKNOWN_PATH)
         line = position.get("line", UNKNOWN_LINE)
+        if line != UNKNOWN_LINE:
+            line = line + 1
         start = position.get("start", 0) + 1
         end = max(position.get("end", 0) + 1, start)
         if path == UNKNOWN_PATH and not method.is_leaf():


### PR DESCRIPTION
Fix line-number being off by one in MT parser.
MT for some reason, reports line number as 0 which can lead to issues in
the frontend. Add one to it to prevent this problem.

This can also be something that is wrong with Mariana Trench as the
general convention is to report line numbers from 1 rather than 0.
Hence this commit is pretty open to debate.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Fixes: https://github.com/MLH-Fellowship/sapp/issues/4