### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==2.0
 click
 click-log
 flask
@@ -15,3 +16,4 @@ prompt-toolkit
 traitlets
 typing-extensions
 pyre-extensions
+zstd


### PR DESCRIPTION

## Summary

We've had two problems come up lately:
- github tests fail because `zstd` is missing from dependencies
- we discovered that we need ot pin `werkzeug==2.0`

## Test Plan

In a new virtualenv:
```
pip install -e .
pip install -r requirements-dev.txt
./scripts/run-tests.sh
```
Also start up a webserver with no import-time errors via:
```
sapp --database-name sapp.db server --source-directory=.
```