### PR TITLE
Patch wrong library 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ prompt-toolkit
 traitlets
 typing-extensions
 pyre-extensions
-zstd
+zstandard

--- a/sapp/json_diagnostics.py
+++ b/sapp/json_diagnostics.py
@@ -35,7 +35,7 @@ from functools import partial
 from multiprocessing import Pool
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Type
 
-import zstd
+import zstandard as zstd
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
 from pygments.lexers import JsonLexer


### PR DESCRIPTION
zstandard library is actually used instead of zstandard . I changed the library to zstandard in requirements.txt and changed the usage as import zstandard as zstd

Take a look at the API - https://python-zstandard.readthedocs.io/en/latest/compressor.html#zstdcompressor
And issue I created https://github.com/facebook/sapp/issues/71