### PR TITLE
Quick fix for #89: Bump pyre-extensions version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ipython<8.4.0
 munch==2.5.0
 prompt-toolkit==3.0.29
 Pygments==2.12.0
-pyre-extensions==0.0.27
+pyre-extensions==0.0.30
 SQLAlchemy<1.4
 traitlets==5.2.2.post1
 typing-extensions==4.2.0


### PR DESCRIPTION
Bump pyre-extensions version in requirements.txt
Since, these are extensions are for the typing module, I think we can remove the version information as well.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the following linters locally and fixed lint errors related to the files I modified in this PR
    - [x] `black .`
    - [x] `usort format .`
    - [x] `flake8`
- [x] I've installed dev dependencies `pip install -r requirements-dev.txt` and completed the following:
    - [x] I've ran tests with `./scripts/run-tests.sh` and made sure all tests are passing

## Summary

A simple version bump for pyre-extensions.
In order to prevent dependency issues in sapp, we decided to pin versions in the requirements.txt. Now a package that pyre-check introduces a dependency conflict as it depends on a newer version of a package (pyre-extensions)
Bumping pyre-extensions which extend the typing module. Since it is non-breaking module (pyre-extensions), we could potentially unpin the versioning information and allow pyre-check to dictate the version. However, I could be wrong here.

## Test Plan

> Ran 102 tests in 5.983s

The frontend tests are failing however, but I strongly believe them to be un-related to this PR.

Fixes #89 
