### PR TITLE
Github actions fix: Have some output for errors

### DIFF
--- a/sapp/ui/filters.py
+++ b/sapp/ui/filters.py
@@ -250,11 +250,7 @@ def filter_run(
         total_filtered_issues_output = (
             f"Total number of issues after filtering: {len(query_results)}"
         )
-        if len(query_results) <= 0:
-            LOG.error(total_filtered_issues_output)
-            return
-        else:
-            LOG.info(total_filtered_issues_output)
+        LOG.info(total_filtered_issues_output)
         if output_format == "sapp":
             output_json = {"issues": [issue.to_json() for issue in query_results]}
             print(json.dumps(output_json, indent=2, default=str))


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the following linters locally and fixed lint errors related to the files I modified in this PR
    - [x] `black .`
    - [x] `usort format .`
    - [x] `flake8`
- [x] I've installed dev dependencies `pip install -r requirements-dev.txt` and completed the following:
    - [x] I've ran tests with `./scripts/run-tests.sh` and made sure all tests are passing

## Summary

SARIF expects some information about tooling when there are no issues, SAPP currently doesn't print any information and exits silently in case there are no issues after applying filters.

Github Actions expects the output to conform to SARIF. Hence, return empty results list along with tooling information as expected by SARIF.

For reference, see: https://github.com/facebook/pysa-action/actions/runs/4534111680
is crashing.

## Test Plan
Before
https://github.com/facebook/pysa-action/actions/runs/4534111680

<img width="1440" alt="Screenshot 2023-03-28 at 4 33 51 PM" src="https://user-images.githubusercontent.com/8947010/228222598-99d750f3-e062-42bd-ac0d-9d0368112d58.png">

After

<img width="1440" alt="Screenshot 2023-03-28 at 4 34 05 PM" src="https://user-images.githubusercontent.com/8947010/228222038-d8c12f4f-4b57-4169-88ce-584aa0dc5d18.png">

<img width="1440" alt="Screenshot 2023-03-28 at 4 33 59 PM" src="https://user-images.githubusercontent.com/8947010/228222326-b880f5e5-1af5-4c46-9cc1-733513affcc4.png">

Fixes possible errors from happening in Github workflows that make use of `sapp-action` or `pysa-action`