### PR TITLE
Adds SARIF traces support to SAPP

### DIFF
--- a/sapp/sarif.py
+++ b/sapp/sarif.py
@@ -51,7 +51,8 @@ class SARIF:
             "pysa": (5000, 6000),
         }
         driver_json = {}
-        if tool == "pysa":
+        self.tool = tool
+        if self.tool == "pysa":
             driver_json["name"] = "Pysa"
             driver_json["informationUri"] = "https://github.com/facebook/pyre-check/"
 
@@ -64,11 +65,26 @@ class SARIF:
             for rule in tool_warning_messages:
                 rules_json.append({"id": str(rule.code), "name": rule.message})
             driver_json["rules"] = rules_json
+        elif self.tool == "mariana-trench":
+            driver_json["name"] = "Mariana Trench"
+            driver_json[
+                "informationUri"
+            ] = "https://github.com/facebook/mariana-trench/"
+
+            tool_warning_messages = get_warning_message_range(
+                session,
+                self._tool_warning_code_ranges[self.tool][0],
+                self._tool_warning_code_ranges[self.tool][1],
+            )
+            rules_json = []
+            for rule in tool_warning_messages:
+                rules_json.append({"id": str(rule.code), "name": rule.message})
+            driver_json["rules"] = rules_json
         else:
             raise NotImplementedError
 
         self.driver = driver_json
-        self.results = [issue.to_sarif() for issue in filtered_issues]
+        self.results = [issue.to_sarif(session, self.tool) for issue in filtered_issues]
 
     def to_json(self, indent: int = 2) -> str:
         return json.dumps(self, cls=SARIFEncoder, indent=indent)

--- a/sapp/sarif.py
+++ b/sapp/sarif.py
@@ -51,40 +51,28 @@ class SARIF:
             "pysa": (5000, 6000),
         }
         driver_json = {}
-        self.tool = tool
-        if self.tool == "pysa":
+        if tool == "pysa":
             driver_json["name"] = "Pysa"
             driver_json["informationUri"] = "https://github.com/facebook/pyre-check/"
-
-            tool_warning_messages = get_warning_message_range(
-                session,
-                self._tool_warning_code_ranges[tool][0],
-                self._tool_warning_code_ranges[tool][1],
-            )
-            rules_json = []
-            for rule in tool_warning_messages:
-                rules_json.append({"id": str(rule.code), "name": rule.message})
-            driver_json["rules"] = rules_json
-        elif self.tool == "mariana-trench":
+        elif tool == "mariana-trench":
             driver_json["name"] = "Mariana Trench"
             driver_json[
                 "informationUri"
             ] = "https://github.com/facebook/mariana-trench/"
-
-            tool_warning_messages = get_warning_message_range(
-                session,
-                self._tool_warning_code_ranges[self.tool][0],
-                self._tool_warning_code_ranges[self.tool][1],
-            )
-            rules_json = []
-            for rule in tool_warning_messages:
-                rules_json.append({"id": str(rule.code), "name": rule.message})
-            driver_json["rules"] = rules_json
         else:
             raise NotImplementedError
 
+        tool_warning_messages = get_warning_message_range(
+            session,
+            self._tool_warning_code_ranges[tool][0],
+            self._tool_warning_code_ranges[tool][1],
+        )
+        rules_json = []
+        for rule in tool_warning_messages:
+            rules_json.append({"id": str(rule.code), "name": rule.message})
+        driver_json["rules"] = rules_json
         self.driver = driver_json
-        self.results = [issue.to_sarif(session, self.tool) for issue in filtered_issues]
+        self.results = [issue.to_sarif(session, tool) for issue in filtered_issues]
 
     def to_json(self, indent: int = 2) -> str:
         return json.dumps(self, cls=SARIFEncoder, indent=indent)

--- a/sapp/sarif_types.py
+++ b/sapp/sarif_types.py
@@ -36,3 +36,10 @@ SARIFResult: TypeAlias = Dict[
         str,
     ],
 ]
+SARIFPhyicalLocationObject: TypeAlias = Dict[
+    str, Union[SARIFRegionObject, Dict[str, str]]
+]
+SARIFCodeflowLocationObject: TypeAlias = Dict[
+    str, Union[SARIFPhyicalLocationObject, Dict[str, str]]
+]
+SARIFCodeflowsObject: TypeAlias = List[Dict[str, List[Dict[str, List]]]]

--- a/sapp/ui/issues.py
+++ b/sapp/ui/issues.py
@@ -254,7 +254,7 @@ class IssueQueryResult(NamedTuple):
         }
         from . import trace
 
-        sarif_result["codeFlows"] = trace.to_sarif(session, self, tool, True)
+        sarif_result["codeFlows"] = trace.to_sarif(session, self, tool, output_features=True)
         return sarif_result
 
     def __hash__(self) -> int:

--- a/sapp/ui/issues.py
+++ b/sapp/ui/issues.py
@@ -234,7 +234,9 @@ class IssueQueryResult(NamedTuple):
             ],
         }
 
-    def to_sarif(self, severity_level: str = "warning") -> SARIFResult:
+    def to_sarif(
+        self, session: Session, tool: str, severity_level: str = "warning"
+    ) -> SARIFResult:
         sarif_result = {
             "ruleId": str(self.code),
             "level": str(SARIFSeverityLevel(severity_level)),
@@ -250,6 +252,9 @@ class IssueQueryResult(NamedTuple):
                 }
             ],
         }
+        from . import trace
+
+        sarif_result["codeFlows"] = trace.to_sarif(session, self, tool, True)
         return sarif_result
 
     def __hash__(self) -> int:


### PR DESCRIPTION

**Pre-submission checklist**
- [✅] I've ran the following linters locally and fixed lint errors related to the files I modified in this PR
    - [✅] `black .`
    - [✅] `usort format .`
    - [✅] `flake8`
- [✅] I've installed dev dependencies `pip install -r requirements-dev.txt` and completed the following:
    - [✅] I've ran tests with `./scripts/run-tests.sh` and made sure all tests are passing



## Summary
This PR adds a sarif output to SAPP traces. Currently SARIF output from SAPP doesn't output the trace of an issue. It just outputs the root node making it triage almost impossible. 

Example of SARIF output on [exercise_3](https://github.com/facebook/pyre-check/blob/main/documentation/pysa_tutorial/exercise3/views.py) from Pysa tutorial is

```
{
          "ruleId": "5001",
          "level": "warning",
          "message": {
            "text": "Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "views.py"
                },
                "region": {
                  "startLine": 24,
                  "startColumn": 19,
                  "endColumn": 36
                }
              }
            }
          ]
        }
```
Notice locations section only shows the root of where the issue is happening but not a full trace
Below is the SARIF output of the same issue after applying this PR
```
{
          "ruleId": "5001",
          "level": "warning",
          "message": {
            "text": "Data from [UserControlled] source(s) may reach [RemoteCodeExecution] sink(s)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "views.py"
                },
                "region": {
                  "startLine": 24,
                  "startColumn": 19,
                  "endColumn": 36
                }
              }
            }
          ],
          "codeFlows": [
            {
              "threadFlows": [
                {
                  "locations": [
                    {
                      "location": {
                        "physicalLocation": {
                          "artifactLocation": {
                            "uri": "views.py",
                            "uriBaseId": "%SRCROOT%"
                          },
                          "region": {
                            "startLine": 14,
                            "startColumn": 16,
                            "endColumn": 28
                          }
                        },
                        "message": {
                          "text": "flow from views.get_operator_safe(...result...) -[into]-> Obj{django.http.request.HttpRequest.POST}(...source...)  features: ['has:first-index', 'first-index:operator']"
                        }
                      },
                      "nestingLevel": 0
                    },
                    {
                      "location": {
                        "physicalLocation": {
                          "artifactLocation": {
                            "uri": "views.py",
                            "uriBaseId": "%SRCROOT%"
                          },
                          "region": {
                            "startLine": 22,
                            "startColumn": 16,
                            "endColumn": 42
                          }
                        },
                        "message": {
                          "text": "flow from views.operate_on_twos(...root...) -[into]-> views.get_operator_safe(...result...) via 1 propagators features: ['always-via:obscure:model', 'always-via:format-string', 'always-via:tito']"
                        }
                      },
                      "nestingLevel": 1
                    },
                    {
                      "location": {
                        "physicalLocation": {
                          "artifactLocation": {
                            "uri": "views.py",
                            "uriBaseId": "%SRCROOT%"
                          },
                          "region": {
                            "startLine": 24,
                            "startColumn": 19,
                            "endColumn": 36
                          }
                        },
                        "message": {
                          "text": "flow from views.operate_on_twos(...root...) -[into]-> eval(...sink...)"
                        }
                      },
                      "nestingLevel": 2
                    }
                  ]
                }
              ]
            }
          ]
        }
```
Notice the new object in SARIF output `codeFlows` 
The PR is heavily inspired by [`_generate_trace_from_issue`](https://github.com/facebook/sapp/blob/ab2aa2e586878e251806c32c13ede53aa36ee91f/sapp/ui/interactive.py#L857-L900) from the interactive output for SAPP

## Test Plan
Analyzed exercise 3 with Pysa https://github.com/facebook/pyre-check/blob/main/documentation/pysa_tutorial/exercise3/ and attached the SARIF before and after
SARIF before this PR: [exercise3_old.sarif.txt](https://github.com/facebook/sapp/files/12049937/exercise3_old.sarif.txt)
SARIF after this PR: [exercise3.sarif.txt](https://github.com/facebook/sapp/files/12049936/exercise3.sarif.txt)
Screenshot before this PR ![Screenshot 2023-07-14 at 12 33 46](https://github.com/facebook/sapp/assets/3219693/0f9dd3dc-a500-4cd3-b373-163e72cbd056)

Screenshot after this PR ![Screenshot 2023-07-14 at 12 33 25](https://github.com/facebook/sapp/assets/3219693/99ac3371-09ea-4d7c-845f-0e16062a72a1)

PS: I noticed there are no unit tests for SARIF output. I am happy to follow-up later with A PR that add some unit tests for SARIF export. 
PS: I have also run the pre-submission checklist but I have noticed that the tests are already broken without any changes from my side. 


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
