### PR TITLE
Fix open source imports for Github tests

### DIFF
--- a/sapp/sarif_types.py
+++ b/sapp/sarif_types.py
@@ -7,8 +7,12 @@
 
 import sys
 from enum import Enum
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, Union
 
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias

--- a/sapp/tests/fake_object_generator.py
+++ b/sapp/tests/fake_object_generator.py
@@ -9,9 +9,8 @@
 import datetime
 from typing import Callable, Optional
 
-from tools.sapp.sapp.models import RunStatus
-
 from ..bulk_saver import BulkSaver
+
 from ..models import (
     ClassTypeInterval,
     DBID,
@@ -23,6 +22,7 @@ from ..models import (
     MetaRun,
     PurgeStatusForInstance,
     Run,
+    RunStatus,
     SharedText,
     SharedTextKind,
     SourceLocation,


### PR DESCRIPTION
Summary: SAPP tests began breaking because of an import error, so this diff fixes the import that causes the issue.

Differential Revision: D47724871

