### PR TITLE
Remove ujson from the .pyre_configuration file

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -3,6 +3,7 @@
     "setup.py",
     "stubs"
   ],
+  "site_package_search_strategy": "pep561",
   "search_path": [
     {
       "site-package": "click"
@@ -35,9 +36,6 @@
       "site-package": "pygments"
     },
     {
-      "site-package": "ujson"
-    },
-    {
       "site-package": "xxhash"
     },
     {
@@ -45,9 +43,6 @@
     },
     {
       "site-package": "traitlets"
-    },
-    {
-      "site-package": "typing_extensions"
     },
     {
       "site-package": "pyre_extensions"


### PR DESCRIPTION
Summary:
Apparently we don't depend on ujson (transitively) anymore.
This is causing Github CI errors: `Invalid configuration: Invalid path ujson: does not exist.`

Differential Revision: D49093816


