### PR TITLE
Update SQLAlchemy==1.4.50

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ munch==2.5.0
 prompt-toolkit==3.0.29
 Pygments==2.12.0
 pyre-extensions==0.0.30
-SQLAlchemy<1.4
+SQLAlchemy==1.4.50
 traitlets==5.2.2.post1
 typing-extensions==4.2.0
 xxhash==3.0.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the following linters locally and fixed lint errors related to the files I modified in this PR
    - [x] `black .`
    - [x] `usort format .`
    - [x] `flake8`
- [x] I've installed dev dependencies `pip install -r requirements-dev.txt` and completed the following:
    - [x] I've ran tests with `./scripts/run-tests.sh` and made sure all tests are passing

## Summary
Updating `SQLAlchemy==1.4.50`. After https://github.com/facebook/sapp/commit/dce94afa2bc1b4c7afb07b038d1baa84f63f1c61  running SAPP returns the following import error 
```
(venv) ielsayed@ibrahims-mbp-2 ~/s/r/l/b/v/l/p/site-packages ((90f4c285))> sapp --database-name=sapp.db --tool=mariana-trench analyze $MT_OUTPUT_DIR/
/python3.11/site-packages/sqlalchemy/orm/relationships.py:1994: SAWarning: Setting backref / back_populates on relationship Run.issue_instances to refer to viewonly relationship IssueInstance.run should include sync_backref=False set on the Run.issue_instances relationship.  (this warning may be suppressed after 10 occurrences)
  util.warn_limited(
/python3.11/site-packages/sqlalchemy/orm/relationships.py:1994: SAWarning: Setting backref / back_populates on relationship IssueInstance.run to refer to viewonly relationship Run.issue_instances should include sync_backref=False set on the IssueInstance.run relationship.  (this warning may be suppressed after 10 occurrences)
  util.warn_limited(
Traceback (most recent call last):
  File "/Users/ielsayed/storm_data/repos/lacework-sapp/build/venv/bin/sapp", line 5, in <module>
    from sapp.cli import cli
  File "python3.11/site-packages/sapp/cli.py", line 13, in <module>
    from .cli_lib import commands, common_options
  File "/python3.11/site-packages/sapp/cli_lib.py", line 29, in <module>
    from .pipeline.database_saver import DatabaseSaver
  File "/python3.11/site-packages/sapp/pipeline/database_saver.py", line 12, in <module>
    from ..bulk_saver import BulkSaver
  File "python3.11/site-packages/sapp/bulk_saver.py", line 13, in <module>
    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
ImportError: cannot import name 'insert' from 'sqlalchemy.dialects.sqlite' (python3.11/site-packages/sqlalchemy/dialects/sqlite/__init__.py)

```
which indeed does NOT exist in [latest version](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3_24/lib/sqlalchemy/dialects/sqlite/__init__.py) <1.4   but [exists in version 1.4.50](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_50/lib/sqlalchemy/dialects/mysql/__init__.py)

1.4.50 is the latest version before 2.0.0 and it is needed by graphene version so I cannot bump SAPP to use latest version from SQLAlchemy

## Test Plan
Re-running the command
```
sapp --database-name=sapp.db --tool=mariana-trench analyze $MT_OUTPUT_DIR/
```
does not produce the same error again
