### PR TITLE
[sapp] fix sqlalchemy cache_ok spew

### DIFF
--- a/sapp/db_support.py
+++ b/sapp/db_support.py
@@ -151,6 +151,7 @@ class DBIDType(types.TypeDecorator):
 
 class BIGDBIDType(DBIDType):
     impl = types.BigInteger
+    cache_ok = True
 
     # pyre-fixme[3]: Return type must be annotated.
     def load_dialect_impl(self, dialect: Dialect):


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ x] I've ran the following linters locally and fixed lint errors related to the files I modified in this PR
    - [ ] `black .`
    - [ ] `usort format .`
    - [ ] `flake8`
- [x ] I've installed dev dependencies `pip install -r requirements-dev.txt` and completed the following:
    - [ ] I've ran tests with `./scripts/run-tests.sh` and made sure all tests are passing

## Summary

`sapp analyze` was spewing SQLAlchemy warnings; looks like they added a caching attribute that must explicitly be set to True or False:

```
SAWarning: TypeDecorator IssueBIGDBIDType() will not produce
a cache key because the ``cache_ok`` attribute is not set to
True.  This can have significant performance implications
including some performance degradations in comparison to
prior SQLAlchemy versions.  Set this attribute to True if
this type object's state is safe to use in a cache key, or
False to disable this warning. (Background on this error at:
https://sqlalche.me/e/14/cprf)
```

The resolution is to add the attribute; seems safe so setting to True.
## Test Plan



Tested by running `sapp analyze` on results from the Zulip codebase; seems to eliminate the spew.


